### PR TITLE
Morphs update

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -226,28 +226,31 @@ export var onMorphTargetsLoaded = function (viewer, morphList) {
         class: 'morph-target-list-container'
     });
 
-
     var theviewer = viewer;
     var currentMeshPanel;
     for (var i = 0; i < morphList.length; ++i) {
         var morph = morphList[i];
-        if (!Number.isFinite(morph.weight)) {
+        if (morph.hasOwnProperty('getWeight')) {
+            var morphTargetContainer = new pcui.Container();
+            morphTargetContainer.buildDom([buildSlider(morph.name, 10, 0, 1, morph.getWeight())]);
+            var slider = morphTargetContainer['_' + morph.name + 'Slider'];
+            slider.on('change', function (morph) {
+                if (this.value !== morph.getWeight()) {
+                    morph.setWeight(this.value);
+                }
+            }.bind(slider, morph));
+            morph.onWeightChanged = function (morph) {
+                this.value = morph.getWeight();
+            }.bind(slider, morph);
+            morphTargetContainer['_' + morph.name + 'SliderLabel'].class.add('morph-target-label');
+            currentMeshPanel.append(morphTargetContainer);
+        } else {
             currentMeshPanel = new pcui.Panel({
                 headerText: morph.name,
                 collapsible: true,
                 class: 'morph-target-panel'
             });
             morphTargetPanel._morphTargetList.append(currentMeshPanel);
-        } else {
-            var morphTargetContainer = new pcui.Container();
-            morphTargetContainer.buildDom([buildSlider(morph.name, 2, 0, 1, morph.weight)]);
-            morphTargetContainer['_' + morph.name + 'Slider'].on('change', (function (morph) {
-                return function () {
-                    theviewer.setMorphWeight(morph, this.value);
-                };
-            })(morph.name));
-            morphTargetContainer['_' + morph.name + 'SliderLabel'].class.add('morph-target-label');
-            currentMeshPanel.append(morphTargetContainer);
         }
     }
     morphTargetPanel.append(morphTargetPanel._morphTargetList);

--- a/src/controls.js
+++ b/src/controls.js
@@ -42,10 +42,10 @@ var buildSlider = function (name, precision, min, max, value, label) {
         max: max,
         sliderMin: min,
         sliderMax: max,
-        step: 0.01
+        step: 0.01,
+        precision: precision
     });
     sliderDom.children[1][name + 'Slider'].value = value;
-    sliderDom.children[1][name + 'Slider'].precision = precision;
     return sliderDom;
 };
 
@@ -232,7 +232,7 @@ export var onMorphTargetsLoaded = function (viewer, morphList) {
         var morph = morphList[i];
         if (morph.hasOwnProperty('getWeight')) {
             var morphTargetContainer = new pcui.Container();
-            morphTargetContainer.buildDom([buildSlider(morph.name, 10, 0, 1, morph.getWeight())]);
+            morphTargetContainer.buildDom([buildSlider(morph.name, 24, 0, 1, morph.getWeight())]);
             var slider = morphTargetContainer['_' + morph.name + 'Slider'];
             slider.on('change', function (morph) {
                 if (this.value !== morph.getWeight()) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -706,7 +706,7 @@ Object.assign(Viewer.prototype, {
             // copy (possibly) animated morph weights to UI widgets
             for (var i = 0; i < this.morphs.length; ++i) {
                 var morph = this.morphs[i];
-                if (morph.hasOwnProperty('onWeightChanged')) {
+                if (morph.onWeightChanged) {
                     morph.onWeightChanged();
                 }
             }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -115,7 +115,6 @@ var Viewer = function (canvas, onSceneReset, onAnimationsLoaded, onMorphTargetsL
     this.graph = graph;
     this.meshInstances = [];
     this.animationMap = { };
-    this.morphMap = { };
     this.morphs = [];
     this.firstFrame = false;
     this.skyboxLoaded = false;
@@ -427,7 +426,6 @@ Object.assign(Viewer.prototype, {
         this.animationMap = { };
         this.onAnimationsLoaded(this, []);
 
-        this.morphMap = { };
         this.morphs = [];
         this.onMorphTargetsLoaded(this, []);
 
@@ -680,18 +678,6 @@ Object.assign(Viewer.prototype, {
         this.renderNextFrame();
     },
 
-    // set the morphing value
-    setMorphWeight: function (name, weight) {
-        if (this.morphMap.hasOwnProperty(name)) {
-            var morphs = this.morphMap[name];
-            morphs.forEach(function (morph) {
-                morph.instance.setWeight(morph.targetIndex, weight);
-            });
-            this.dirtyNormals = true;
-            this.renderNextFrame();
-        }
-    },
-
     update: function () {
         // if the camera has moved since the last render
         var cameraWorldTransform = this.camera.getWorldTransform();
@@ -701,15 +687,27 @@ Object.assign(Viewer.prototype, {
         }
 
         // or an animation is loaded and we're animating
+        var isAnimationPlaying = false;
         for (var key in this.animationMap) {
             if (this.animationMap.hasOwnProperty(key)) {
-                var layer = this.animationMap[key];
-                if (layer.playing) {
-                    this.dirtyBounds = true;
-                    this.dirtySkeleton = true;
-                    this.dirtyNormals = true;
-                    this.renderNextFrame();
+                if (this.animationMap[key].playing) {
+                    isAnimationPlaying = true;
                     break;
+                }
+            }
+        }
+
+        if (isAnimationPlaying) {
+            this.dirtyBounds = true;
+            this.dirtySkeleton = true;
+            this.dirtyNormals = true;
+            this.renderNextFrame();
+
+            // copy (possibly) animated morph weights to UI widgets
+            for (var i = 0; i < this.morphs.length; ++i) {
+                var morph = this.morphs[i];
+                if (morph.hasOwnProperty('onWeightChanged')) {
+                    morph.onWeightChanged();
                 }
             }
         }
@@ -820,6 +818,7 @@ Object.assign(Viewer.prototype, {
             return;
         }
 
+        var self = this;
         var resource = asset.resource;
 
         var entity;
@@ -931,20 +930,26 @@ Object.assign(Viewer.prototype, {
         if (entity.model && entity.model.model && entity.model.model.morphInstances.length > 0) {
             var morphInstances = entity.model.model.morphInstances;
             // make a list of all the morph instance target names
-            var morphMap = this.morphMap;
             var morphs = this.morphs;
             morphInstances.forEach(function (morphInstance, morphIndex) {
                 // mesh name line
-                morphs.push({ name: "Mesh " + morphIndex });
+                var meshInstance = morphInstance.meshInstance;
+                var name = meshInstance && meshInstance.node && meshInstance.node.name;
+                morphs.push({
+                    name: name || "Mesh " + morphIndex
+                });
 
                 morphInstance.morph._targets.forEach(function (target, targetIndex) {
-                    var targetName = morphIndex + "-" + target.name;
-                    if (!morphMap.hasOwnProperty(targetName)) {
-                        morphMap[targetName] = [{ instance: morphInstance, targetIndex: targetIndex }];
-                        morphs.push({ name: targetName, weight: target.defaultWeight });
-                    } else {
-                        morphMap[targetName].push({ instance: morphInstance, targetIndex: targetIndex });
-                    }
+                    morphs.push({
+                        name: target.name,
+                        setWeight: function (targetIndex, weight) {
+                            this.setWeight(targetIndex, weight);
+                            self.dirtyNormals = true;
+                            self.renderNextFrame();
+                        }.bind(morphInstance, targetIndex),
+                        getWeight: pc.MorphInstance.prototype.getWeight.bind(morphInstance, targetIndex),
+                        onWeightChanged: null    // controls can set this to a function for receiving weight updates
+                    });
                 });
             });
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -932,13 +932,14 @@ Object.assign(Viewer.prototype, {
             // make a list of all the morph instance target names
             var morphs = this.morphs;
             morphInstances.forEach(function (morphInstance, morphIndex) {
-                // mesh name line
                 var meshInstance = morphInstance.meshInstance;
-                var name = meshInstance && meshInstance.node && meshInstance.node.name;
+
+                // mesh name line
                 morphs.push({
-                    name: name || "Mesh " + morphIndex
+                    name: (meshInstance && meshInstance.node && meshInstance.node.name) || "Mesh " + morphIndex
                 });
 
+                // morph targets
                 morphInstance.morph._targets.forEach(function (target, targetIndex) {
                     morphs.push({
                         name: target.name,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
         ],
         extensions: ['.js', '.css']
     },
-    devtool: 'source-map',
+    devtool: 'inline-source-map',
     context: __dirname,
     target: 'web',
     devServer: {


### PR DESCRIPTION
This PR cleans up the viewer blendshape support, specifically:
- clean up morph referencing/indexing by removing unnecessary morphMap
- name morph groups nicely (instead of using mesh index)
- update morph weight sliders when playing animations

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
