### PR TITLE
Update webpacks sourcemap config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
         ],
         extensions: ['.js', '.css']
     },
-    devtool: 'inline-source-map',
+    devtool: process.env.ENVIRONMENT === 'production' ? 'source-map' : 'eval-source-map',
     context: __dirname,
     target: 'web',
     devServer: {


### PR DESCRIPTION
This PR sets the webpack source map config to two different presets based on the build type:

Local development (`npm run watch`):
```
eval-source-map - Each module is executed with eval() and a SourceMap is added as a DataUrl to the eval(). Initially it is slow, but it provides fast rebuild speed and yields real files. Line numbers are correctly mapped since it gets mapped to the original code. It yields the best quality SourceMaps for development.
```

Dev server & prod server (`npm run build:server`):
```
source-map - A full SourceMap is emitted as a separate file. It adds a reference comment to the bundle so development tools know where to find it.
``` 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
