### PR TITLE
Fix HDR issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.DS_Store

--- a/src/lib/hdr-texture.js
+++ b/src/lib/hdr-texture.js
@@ -80,7 +80,9 @@ Object.assign(HdrParser.prototype, {
             height: textureData.height,
             levels: textureData.levels,
             format: pc.PIXELFORMAT_R8_G8_B8_A8,
-            type: pc.TEXTURETYPE_RGBE
+            type: pc.TEXTURETYPE_RGBE,
+            // RGBE can't be filtered, so mipmaps are out of the question! (unless we generated them ourselves)
+            mipmaps: false
         });
 
         texture.upload();


### PR DESCRIPTION
Disable HDR format mipmaps because RGBE pixels can't be filtered (and so the the auto-generated versions are wrong).

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
