### PR TITLE
Support local builds of the playcanvas engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "serve": "serve dist",
     "build": "webpack --config webpack.config.js",
     "build:watch": "webpack --config webpack.config.js --watch",
-    "build:localplaycanvas": "PLAYCANVAS_IMPORT=local webpack --config webpack.config.js --watch",
-    "build:localplaycanvasdbg": "PLAYCANVAS_IMPORT=localdebug webpack --config webpack.config.js --watch",
+    "build:localplaycanvas": "PLAYCANVAS_PATH=local webpack --config webpack.config.js --watch",
+    "build:localplaycanvasdbg": "PLAYCANVAS_PATH=localdebug webpack --config webpack.config.js --watch",
     "build:server": "ENVIRONMENT=production PUBLIC_PATH=/viewer/static/ webpack --config webpack.config.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,14 +34,15 @@
     "playcanvas": "^1.32.4",
     "style-loader": "^1.2.1",
     "webpack": "^4.44.0",
-    "webpack-cli": "^3.3.12",
-    "webpack-conditional-loader": "^1.0.12"
+    "webpack-cli": "^3.3.12"
   },
   "scripts": {
     "lint": "eslint --ignore-pattern 'src/lib' --ext .js src",
     "serve": "serve dist",
     "build": "webpack --config webpack.config.js",
     "build:watch": "webpack --config webpack.config.js --watch",
+    "build:localplaycanvas": "PLAYCANVAS_IMPORT=local webpack --config webpack.config.js --watch",
+    "build:localplaycanvasdbg": "PLAYCANVAS_IMPORT=localdebug webpack --config webpack.config.js --watch",
     "build:server": "ENVIRONMENT=production PUBLIC_PATH=/viewer/static/ webpack --config webpack.config.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
     "serve": "serve dist",
     "build": "webpack --config webpack.config.js",
     "build:watch": "webpack --config webpack.config.js --watch",
-    "build:localplaycanvas": "PLAYCANVAS_PATH=local webpack --config webpack.config.js --watch",
-    "build:localplaycanvasdbg": "PLAYCANVAS_PATH=localdebug webpack --config webpack.config.js --watch",
     "build:server": "ENVIRONMENT=production PUBLIC_PATH=/viewer/static/ webpack --config webpack.config.js"
   },
   "dependencies": {

--- a/src/controls.js
+++ b/src/controls.js
@@ -1,6 +1,6 @@
 import * as pcui from './lib/pcui.js';
 import { getAssetPath } from './helpers.js';
-const pc = require(__PLAYCANVAS_IMPORT__);
+var pc = require(__PLAYCANVAS_IMPORT__);
 
 // Build controls
 var controlsDiv = document.getElementById('controls');

--- a/src/controls.js
+++ b/src/controls.js
@@ -1,6 +1,6 @@
 import * as pcui from './lib/pcui.js';
-import { http } from 'playcanvas';
 import { getAssetPath } from './helpers.js';
+const pc = require(__PLAYCANVAS_IMPORT__);
 
 // Build controls
 var controlsDiv = document.getElementById('controls');
@@ -111,7 +111,7 @@ lightingPanel.buildDom(lightingPanelDom());
 controlsDiv.append(lightingPanel.dom);
 
 // populate select inputs with manifest assets
-http.get(
+pc.http.get(
     getAssetPath("asset_manifest.json"),
     {
         cache: true,

--- a/src/controls.js
+++ b/src/controls.js
@@ -1,6 +1,6 @@
 import * as pcui from './lib/pcui.js';
 import { getAssetPath } from './helpers.js';
-var pc = require(__PLAYCANVAS_IMPORT__);
+var pc = require(__PLAYCANVAS_PATH__);
 
 // Build controls
 var controlsDiv = document.getElementById('controls');

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,9 +1,5 @@
 var getAssetPath = function (assetPath) {
-    var prefix = '/static/';
-    // #if process.env.PUBLIC_PATH
-    prefix = '/viewer/static/';
-    // #endif
-    return prefix + assetPath;
+    return (__PUBLIC_PATH__ ? __PUBLIC_PATH__ : '/static/') + assetPath;
 };
 
 export { getAssetPath };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-var pc = require(__PLAYCANVAS_IMPORT__);
+var pc = require(__PLAYCANVAS_PATH__);
 import { wasmSupported, loadWasmModuleAsync } from './lib/wasm-loader.js';
 
 import Viewer from './viewer.js';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const pc = require(__PLAYCANVAS_IMPORT__);
+var pc = require(__PLAYCANVAS_IMPORT__);
 import { wasmSupported, loadWasmModuleAsync } from './lib/wasm-loader.js';
 
 import Viewer from './viewer.js';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import * as pc from 'playcanvas';
+const pc = require(__PLAYCANVAS_IMPORT__);
 import { wasmSupported, loadWasmModuleAsync } from './lib/wasm-loader.js';
 
 import Viewer from './viewer.js';

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,5 +1,5 @@
-const pc = require(__PLAYCANVAS_IMPORT__);
-const pcx = require(__PLAYCANVAS_EXTRAS_IMPORT__);
+var pc = require(__PLAYCANVAS_IMPORT__);
+var pcx = require(__PLAYCANVAS_EXTRAS_IMPORT__);
 import Graph from './graph.js';
 import DebugLines from './debug.js';
 import HdrParser from './lib/hdr-texture.js';

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,5 +1,5 @@
-import * as pc from 'playcanvas';
-import { MiniStats } from 'playcanvas/build/playcanvas-extras.js';
+const pc = require(__PLAYCANVAS_IMPORT__);
+const pcx = require(__PLAYCANVAS_EXTRAS_IMPORT__);
 import Graph from './graph.js';
 import DebugLines from './debug.js';
 import HdrParser from './lib/hdr-texture.js';
@@ -132,7 +132,7 @@ var Viewer = function (canvas, onSceneReset, onAnimationsLoaded, onMorphTargetsL
     this.debugNormals = new DebugLines(app, camera);
 
     // construct ministats, default off
-    this.miniStats = new MiniStats(app);
+    this.miniStats = new pcx.MiniStats(app);
     this.miniStats.enabled = false;
 
     // initialize the envmap

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,5 +1,5 @@
-var pc = require(__PLAYCANVAS_IMPORT__);
-var pcx = require(__PLAYCANVAS_EXTRAS_IMPORT__);
+var pc = require(__PLAYCANVAS_PATH__);
+var pcx = require(__PLAYCANVAS_EXTRAS_PATH__);
 import Graph from './graph.js';
 import DebugLines from './debug.js';
 import HdrParser from './lib/hdr-texture.js';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 
-function getPlaycanvasImport() {
-    switch (process.env.PLAYCANVAS_IMPORT) {
+function getPlaycanvasPath() {
+    switch (process.env.PLAYCANVAS_PATH) {
         case 'local':
             return JSON.stringify('./engine/playcanvas.js');
         case 'localdebug':
@@ -14,8 +14,8 @@ function getPlaycanvasImport() {
     }
 }
 
-function getPlaycanvasExtrasImport() {
-    switch (process.env.PLAYCANVAS_IMPORT) {
+function getPlaycanvasExtrasPath() {
+    switch (process.env.PLAYCANVAS_PATH) {
         case 'local':
         case 'localdebug':
             return JSON.stringify('./engine/playcanvas-extras.js');
@@ -73,8 +73,8 @@ module.exports = {
             ]
         }),
         new webpack.DefinePlugin({
-            __PLAYCANVAS_IMPORT__: getPlaycanvasImport(),
-            __PLAYCANVAS_EXTRAS_IMPORT__: getPlaycanvasExtrasImport(),
+            __PLAYCANVAS_PATH__: getPlaycanvasPath(),
+            __PLAYCANVAS_EXTRAS_PATH__: getPlaycanvasExtrasPath(),
             __PUBLIC_PATH__: JSON.stringify(process.env.PUBLIC_PATH)
         })
     ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,27 +3,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 
-function getPlaycanvasPath() {
-    switch (process.env.PLAYCANVAS_PATH) {
-        case 'local':
-            return JSON.stringify('./engine/playcanvas.js');
-        case 'localdebug':
-            return JSON.stringify('./engine/playcanvas.dbg.js');
-        default:
-            return JSON.stringify('playcanvas');
-    }
-}
-
-function getPlaycanvasExtrasPath() {
-    switch (process.env.PLAYCANVAS_PATH) {
-        case 'local':
-        case 'localdebug':
-            return JSON.stringify('./engine/playcanvas-extras.js');
-        default:
-            return JSON.stringify('playcanvas/build/playcanvas-extras.js');
-    }
-}
-
 module.exports = {
     mode: process.env.ENVIRONMENT || 'development',
     entry: './src/index.js',
@@ -73,8 +52,8 @@ module.exports = {
             ]
         }),
         new webpack.DefinePlugin({
-            __PLAYCANVAS_PATH__: getPlaycanvasPath(),
-            __PLAYCANVAS_EXTRAS_PATH__: getPlaycanvasExtrasPath(),
+            __PLAYCANVAS_PATH__: JSON.stringify(process.env.ENGINE_PATH ? path.resolve(__dirname, process.env.ENGINE_PATH) : 'playcanvas'),
+            __PLAYCANVAS_EXTRAS_PATH__: JSON.stringify('playcanvas/build/playcanvas-extras.js'),
             __PUBLIC_PATH__: JSON.stringify(process.env.PUBLIC_PATH)
         })
     ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,28 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const webpack = require('webpack');
+
+function getPlaycanvasImport() {
+    switch (process.env.PLAYCANVAS_IMPORT) {
+        case 'local':
+            return JSON.stringify('./engine/playcanvas.js');
+        case 'localdebug':
+            return JSON.stringify('./engine/playcanvas.dbg.js');
+        default:
+            return JSON.stringify('playcanvas');
+    }
+}
+
+function getPlaycanvasExtrasImport() {
+    switch (process.env.PLAYCANVAS_IMPORT) {
+        case 'local':
+        case 'localdebug':
+            return JSON.stringify('./engine/playcanvas-extras.js');
+        default:
+            return JSON.stringify('playcanvas/build/playcanvas-extras.js');
+    }
+}
 
 module.exports = {
     mode: process.env.ENVIRONMENT || 'development',
@@ -15,10 +37,6 @@ module.exports = {
             {
                 test: /\.css$/,
                 use: ['style-loader', 'css-loader']
-            },
-            {
-                test: /\.js$/,
-                use: ['webpack-conditional-loader']
             }
         ]
     },
@@ -53,6 +71,11 @@ module.exports = {
             patterns: [
                 { from: 'static', to: '' }
             ]
+        }),
+        new webpack.DefinePlugin({
+            __PLAYCANVAS_IMPORT__: getPlaycanvasImport(),
+            __PLAYCANVAS_EXTRAS_IMPORT__: getPlaycanvasExtrasImport(),
+            __PUBLIC_PATH__: JSON.stringify(process.env.PUBLIC_PATH)
         })
     ]
 };


### PR DESCRIPTION
Fixes #41 

Allows the playcanvas-viewer to be built with a local version of the engine. You can supply the engine path as follows:
`ENGINE_PATH=../engine/build/playcanvas.js npm run build:watch`

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
