### PR TITLE
Server build typescript error fix

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -1,4 +1,5 @@
-import * as pcui from '../lib/pcui.js';
+// @ts-ignore: library file import
+import * as pcui from 'lib/pcui.js';
 import { getAssetPath } from './helpers';
 import * as pc from 'playcanvas';
 import Viewer from './viewer.js';

--- a/src/cta.ts
+++ b/src/cta.ts
@@ -1,4 +1,5 @@
-import * as pcui from '../lib/pcui.js';
+// @ts-ignore: library file import
+import * as pcui from 'lib/pcui.js';
 
 const cta = new pcui.InfoBox({
     text: 'Drag glTF or glb files here to view',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as pc from 'playcanvas';
-
-import { wasmSupported, loadWasmModuleAsync } from '../lib/wasm-loader.js';
+// @ts-ignore: library file import
+import { wasmSupported, loadWasmModuleAsync } from 'lib/wasm-loader.js';
 
 import Viewer from './viewer';
 import { onSceneReset, onAnimationsLoaded, onMorphTargetsLoaded, registerElementEvents } from './controls';

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -3,8 +3,10 @@ import * as pc from 'playcanvas';
 import * as pcx from 'playcanvas/build/playcanvas-extras.js';
 import Graph from './graph';
 import DebugLines from './debug';
-import HdrParser from '../lib/hdr-texture.js';
-import * as MeshoptDecoder from '../lib/meshopt_decoder.js';
+// @ts-ignore: library file import
+import HdrParser from 'lib/hdr-texture.js';
+// @ts-ignore: library file import
+import * as MeshoptDecoder from 'lib/meshopt_decoder.js';
 import { getAssetPath } from './helpers';
 
 interface Morph {


### PR DESCRIPTION
The library files don't have any typescript definitions, so they're throwing errors when picked up by the typescript compiler. This ensures they're always ignored.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
