### PR TITLE
[FIX] Load equi skybox at startup

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,7 +104,7 @@ new pc.Http().get(
             });
             const skyboxData = observer.get('lighting.skybox');
             skyboxData.options = JSON.stringify(skyboxOptions);
-            skyboxData.default = result.defaultSkybox;
+            skyboxData.default = getAssetPath(result.defaultSkybox);
             observer.set('lighting.skybox', skyboxData);
             dependencyArrived();
         }

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -208,7 +208,9 @@ class Viewer {
 
         // load the default skybox if one wasn't specified in url params
         if (!this.skyboxLoaded) {
-            this.loadHeliSkybox();
+            // this.loadHeliSkybox();
+            const skybox = observer.get('lighting.skybox.default');
+            this.load([{ url: skybox, filename: skybox }]);
         }
 
         // set camera position


### PR DESCRIPTION
Instead of loading the large prefiltered DDS

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
