### PR TITLE
Add app manifest

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -11,6 +11,7 @@
     <% } else { %>
     <link rel="icon" type="image/png" href="./playcanvas-logo.png" />
     <% } %>
+    <link rel="manifest" href="manifest.json">
 </head>
 
 <body>

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,18 @@
+{
+    "background_color": "black",
+    "categories": ["productivity", "utilities"],
+    "description": "Fast and lightweight glTF viewer.",
+    "dir": "auto",
+    "display": "standalone",
+    "icons": [{
+        "src": "playcanvas-logo.png",
+        "sizes": "64x64",
+        "type": "image/png"
+    }],
+    "lang": "en-US",
+    "name": "PlayCanvas glTF Viewer",
+    "orientation": "any",
+    "prefer_related_applications": false,
+    "short_name": "glTF Viewer",
+    "start_url": "."
+}


### PR DESCRIPTION
Adds an app manifest for installing the viewer to a device's home screen.

Fixes #65

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
