### PR TITLE
Expose tonemapping selection

### DIFF
--- a/src/controls.tsx
+++ b/src/controls.tsx
@@ -63,6 +63,7 @@ const LightingPanel = () => {
         <Panel headerText='LIGHTING' collapsible>
             <Slider name='lightingDirect' precision={2} min={0} max={6} path='lighting.direct' label='Direct' />
             <Slider name='lightingEnv' precision={2} min={0} max={6} path='lighting.env' label='Env' />
+            <Select name='lightingTonemapping' type='string' options={['Linear', 'Filmic', 'Hejl', 'ACES'].map(v => ({ v, t: v }))} path='lighting.tonemapping' label='Tonemap' />
             <Select name='lightingSkybox' type='string' options={skyboxOptions} path='lighting.skybox.value' label='Skybox' />
             <Select name='lightingSkyboxMip' type='number' options={[0, 1, 2, 3, 4, 5, 6].map(v => ({ v, t: Number(v).toString() }))} path='lighting.skybox.mip' label='Mip' />
             <Slider name='lightingRotation' precision={0} min={-180} max={180} path='lighting.rotation' label='Rotation' />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ const observer: Observer = new Observer({
     lighting: {
         direct: 1,
         env: 1,
+        tonemapping: 'ACES',
         skybox: {
             mip: 1,
             value: null,
@@ -68,7 +69,7 @@ ReactDOM.render(
     document.getElementById('app')
 );
 
-let awaiting = 2;
+let awaiting = 3;
 function dependencyArrived() {
     if (--awaiting === 0) {
         // @ts-ignore: Assign global viewer
@@ -117,4 +118,9 @@ new pc.Http().get(
 loadWasmModuleAsync('DracoDecoderModule',
                     wasmSupported() ? getAssetPath('lib/draco/draco.wasm.js') : getAssetPath('lib/draco/draco.js'),
                     wasmSupported() ? getAssetPath('lib/draco/draco.wasm.wasm') : '',
+                    dependencyArrived);
+
+loadWasmModuleAsync('BASISU',
+                    getAssetPath('lib/basisu/basisu.js'),
+                    getAssetPath('lib/basisu/basisu.wasm'),
                     dependencyArrived);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,7 +69,7 @@ ReactDOM.render(
     document.getElementById('app')
 );
 
-let awaiting = 3;
+let awaiting = 2;
 function dependencyArrived() {
     if (--awaiting === 0) {
         // @ts-ignore: Assign global viewer
@@ -118,9 +118,4 @@ new pc.Http().get(
 loadWasmModuleAsync('DracoDecoderModule',
                     wasmSupported() ? getAssetPath('lib/draco/draco.wasm.js') : getAssetPath('lib/draco/draco.js'),
                     wasmSupported() ? getAssetPath('lib/draco/draco.wasm.wasm') : '',
-                    dependencyArrived);
-
-loadWasmModuleAsync('BASISU',
-                    getAssetPath('lib/basisu/basisu.js'),
-                    getAssetPath('lib/basisu/basisu.wasm'),
                     dependencyArrived);

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -162,6 +162,7 @@ class Viewer {
         this.directLightingFactor = observer.get('lighting.direct');
         this.envLightingFactor = observer.get('lighting.env');
         this.skyboxMip = observer.get('lighting.skybox.mip');
+        this.setTonemapping(observer.get('lighting.tonemapping'));
 
         this.dirtyWireframe = false;
         this.dirtyBounds = false;
@@ -309,6 +310,7 @@ class Viewer {
 
         this.observer.on('lighting.direct:set', this.setDirectLighting.bind(this));
         this.observer.on('lighting.env:set', this.setEnvLighting.bind(this));
+        this.observer.on('lighting.tonemapping:set', this.setTonemapping.bind(this));
         this.observer.on('lighting.skybox.mip:set', this.setSkyboxMip.bind(this));
         this.observer.on('lighting.skybox.value:set', (value: string) => {
             if (value) {
@@ -400,10 +402,34 @@ class Viewer {
 
         // assign the textures to the scene
         app.scene.gammaCorrection = pc.GAMMA_SRGB;
-        app.scene.toneMapping = pc.TONEMAP_ACES;
         app.scene.skyboxMip = this.skyboxMip;               // Set the skybox to the 128x128 cubemap mipmap level
         app.scene.setSkybox(cubemaps);
         app.renderNextFrame = true;                         // ensure we render again when the cubemap arrives
+    }
+
+    private compressPngToBasis(url: string) {
+        // @ts-ignore
+        pc.http.get(
+            url,
+            { responseType: 'arraybuffer' },
+            function (err: string | null, result: ArrayBuffer) {
+                if (err) {
+                    console.error(err, result);
+                } else {
+                    // @ts-ignore
+                    const basisu = window.BASISU;
+
+                    // write the input file
+                    basisu.FS.writeFile('input.png', new Int8Array(result));
+
+                    // perform basis compression
+                    basisu.callMain(['input.png', '-no_multithreading', '-mipmap', '-y_flip']);
+
+                    // read back the resulting file data
+                    var result = basisu.FS.readFile('input.basis', { encoding: 'binary' }).buffer;
+                }
+            }
+        );
     }
 
     // load the image files into the skybox. this function supports loading a single equirectangular
@@ -424,6 +450,8 @@ class Viewer {
                     texture.type = pc.TEXTURETYPE_RGBM;
                 }
                 this.initSkyboxFromTexture(texture);
+
+                this.compressPngToBasis(textureAsset.file.url);
             });
             app.assets.add(textureAsset);
             app.assets.load(textureAsset);
@@ -497,7 +525,6 @@ class Viewer {
         });
         cubemap.on('load', function () {
             app.scene.gammaCorrection = pc.GAMMA_SRGB;
-            app.scene.toneMapping = pc.TONEMAP_ACES;
             app.scene.skyboxMip = this.skyboxMip;                   // Set the skybox to the 128x128 cubemap mipmap level
             app.scene.setSkybox(cubemap.resources);
             app.renderNextFrame = true;                             // ensure we render again when the cubemap arrives
@@ -829,6 +856,18 @@ class Viewer {
 
     setEnvLighting(factor: number) {
         this.app.scene.skyboxIntensity = factor;
+        this.renderNextFrame();
+    }
+
+    setTonemapping(tonemapping: string) {
+        const mapping = {
+            Linear: pc.TONEMAP_LINEAR,
+            Filmic: pc.TONEMAP_FILMIC,
+            Hejl: pc.TONEMAP_HEJL,
+            ACES: pc.TONEMAP_ACES
+        };
+        // @ts-ignore
+        this.app.scene.toneMapping = mapping.hasOwnProperty(tonemapping) ? mapping[tonemapping] : pc.TONEMAP_ACES;
         this.renderNextFrame();
     }
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -407,31 +407,6 @@ class Viewer {
         app.renderNextFrame = true;                         // ensure we render again when the cubemap arrives
     }
 
-    private compressPngToBasis(url: string) {
-        // @ts-ignore
-        pc.http.get(
-            url,
-            { responseType: 'arraybuffer' },
-            function (err: string | null, result: ArrayBuffer) {
-                if (err) {
-                    console.error(err, result);
-                } else {
-                    // @ts-ignore
-                    const basisu = window.BASISU;
-
-                    // write the input file
-                    basisu.FS.writeFile('input.png', new Int8Array(result));
-
-                    // perform basis compression
-                    basisu.callMain(['input.png', '-no_multithreading', '-mipmap', '-y_flip']);
-
-                    // read back the resulting file data
-                    var result = basisu.FS.readFile('input.basis', { encoding: 'binary' }).buffer;
-                }
-            }
-        );
-    }
-
     // load the image files into the skybox. this function supports loading a single equirectangular
     // skybox image or 6 cubemap faces.
     private loadSkybox(files: Array<URL>) {
@@ -450,8 +425,6 @@ class Viewer {
                     texture.type = pc.TEXTURETYPE_RGBM;
                 }
                 this.initSkyboxFromTexture(texture);
-
-                this.compressPngToBasis(textureAsset.file.url);
             });
             app.assets.add(textureAsset);
             app.assets.load(textureAsset);


### PR DESCRIPTION
Fixes #76

Adds tonemapping selection:
<img width="348" alt="Screenshot 2020-11-19 at 15 20 48" src="https://user-images.githubusercontent.com/11276292/99685746-d56d0300-2a7a-11eb-9246-d70f813f60a9.png">

Default is ACES.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
