### PR TITLE
Implicit code to specify 2d texture uses equirect projection instead

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -375,6 +375,8 @@ class Viewer {
                 cubemaps.push(reprojectToCubemap(skybox, skybox.width));
             }
         } else {
+            // @ts-ignore TODO type property missing from pc.Texture
+            skybox.projection = pc.TEXTUREPROJECTION_EQUIRECT;
             // reproject equirect to cubemap for skybox
             cubemaps.push(reprojectToCubemap(skybox, skybox.width / 4));
         }


### PR DESCRIPTION
instead of depending on defaults