### PR TITLE
Update PlayCanvas to 1.39.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13536,9 +13536,9 @@
       }
     },
     "playcanvas": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-1.39.0.tgz",
-      "integrity": "sha512-DlUp9a6b2+fWBqwpIuDnhnqoHvbseM9RjL2jLVl8jqbCeJgFuoZNIyZzwiMsVmyo3jQk3xYf1pOU54y1Z0Pzfw==",
+      "version": "1.39.4",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-1.39.4.tgz",
+      "integrity": "sha512-Punv/ioNkWejfPQevEadYiQ9qQe4M4mYYG13uyCWCjhExsD32E9fV24igKue6ASJjVW0i3EiaN5Nu6HNaM6BGA==",
       "dev": true
     },
     "pn": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "css-loader": "^5.0.2",
     "eslint": "^7.19.0",
     "html-webpack-plugin": "^5.0.0",
-    "playcanvas": "^1.39.0",
+    "playcanvas": "^1.39.4",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "serve": "^11.3.2",

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,3 +1,5 @@
+import * as pc from 'playcanvas';
+
 let debugLayerFront: pc.Layer = null;
 let debugLayerBack: pc.Layer = null;
 

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,3 +1,5 @@
+import * as pc from 'playcanvas';
+
 interface IGraph {
     node: pc.GraphNode,
     color: pc.Color,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
-// @ts-ignore: library file import... TODO change this import to 'playcanvas'
-import * as pc from 'playcanvas/build/playcanvas.js';
+import * as pc from 'playcanvas';
 import React from 'react';
 import ReactDOM from 'react-dom';
 // @ts-ignore: library file import

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,5 +1,4 @@
-// @ts-ignore: library file import... TODO change this import to 'playcanvas'
-import * as pc from 'playcanvas/build/playcanvas.js';
+import * as pc from 'playcanvas';
 // @ts-ignore: No extras declarations
 import * as pcx from 'playcanvas/build/playcanvas-extras.js';
 import Graph from './graph';


### PR DESCRIPTION
This PR updates the PlayCanvas NPM package from 1.39.0 to 1.39.4. This requires the app to explicitly import `pc` as follows:

```typescript
import * as pc from 'playcanvas';
```

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
