### PR TITLE
Animation Timeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6011,6 +6011,16 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -10025,6 +10035,13 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -11907,6 +11924,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }
@@ -19282,6 +19300,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -20072,6 +20091,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/src/controls.tsx
+++ b/src/controls.tsx
@@ -75,19 +75,28 @@ const AnimationPanel = () => {
     const observer: Observer = useContext(ObserverContext);
     const playing: boolean = useObserverState(observer, 'animation.playing');
     const animationsList: Array<string> = useObserverState(observer, 'animation.list', true);
-    const enabled =  animationsList.length > 0;
+    const enabled: boolean =  animationsList.length > 0;
+    let selectTrackOptions: Array<{ v: string, t: string }> = animationsList.map((animation: string) => ({ v: animation, t: animation }));
+    if (selectTrackOptions.length > 1) {
+        selectTrackOptions = [{ v: 'ALL_TRACKS', t: 'All tracks' }, ...selectTrackOptions];
+        if (!animationsList.includes(observer.get('animation.selectedTrack'))) {
+            observer.set('animation.selectedTrack', selectTrackOptions[0].v);
+        }
+    } else if (selectTrackOptions.length === 1) {
+        observer.set('animation.selectedTrack', selectTrackOptions[0].v);
+    }
+    const allTracks: boolean = useObserverState(observer, 'animation.selectedTrack') === 'ALL_TRACKS';
     return (
         <Panel headerText='ANIMATION' collapsible>
+            <Select name='animationTrack' type='string' options={selectTrackOptions} path='animation.selectedTrack' label='Track' enabled={enabled} />
             <Container class='panel-option'>
                 <Button icon={ playing ? 'E376' : 'E286' } text='' onClick={() => observer.set('animation.playing', !observer.get('animation.playing'))} enabled={enabled} />
             </Container>
             <Slider name='animationSpeed' precision={2} min={0} max={4} path='animation.speed' label='Speed' enabled={enabled} />
-            <Slider name='animationTransition' precision={2} min={0} max={4} path='animation.transition' label='Transition' enabled={enabled} />
-            <Select name='animationLoops' type='number' options={[1, 2, 3, 4].map(v => ({ v, t: Number(v).toString() }))} path='animation.loops' label='Loops' enabled={enabled} />
+            { !allTracks && <Slider name='animationFrameTimeline' precision={2} min={0} max={1} path='animation.progress' label='Timeline' enabled={enabled} /> }
+            { allTracks && <Slider name='animationTransition' precision={2} min={0} max={4} path='animation.transition' label='Transition' enabled={enabled} /> }
+            { allTracks && <Select name='animationLoops' type='number' options={[1, 2, 3, 4].map(v => ({ v, t: Number(v).toString() }))} path='animation.loops' label='Loops' enabled={enabled} /> }
             <Toggle name='animationGraph' path='animation.graphs' label='Graphs' enabled={enabled} />
-            <Container>
-                {animationsList.map((animation: string) => <Container key={animation} class='panel-option'><Button text={animation} onClick={() => observer.set('animation.playAnimation', animation)}></Button></Container>)}
-            </Container>
         </Panel>
     );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,7 +50,8 @@ const observer: Observer = new Observer({
         loops: 1,
         graphs: false,
         list: '[]',
-        playAnimation: null
+        progress: 0,
+        selectedTrack: 'ALL_TRACKS'
     },
     morphTargets: null,
     spinner: false,

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -794,6 +794,7 @@ class Viewer {
     setAnimationProgress(progress: number) {
         this.observer.set('animation.playing', false);
         this.entities.forEach(e => {
+            // @ts-ignore
             const anim = e.anim;
             anim.playing = true;
             anim.baseLayer.activeStateCurrentTime = anim.baseLayer.activeStateDuration * progress;


### PR DESCRIPTION
Animation tracks are now displayed in a dropdown rather than individual buttons.
The dropdown has an extra option 'All tracks' which will play all animation tracks sequentially.

Different animation controls will now display depending on whether playing a single track or all tracks:

![image](https://user-images.githubusercontent.com/1721533/109168469-c337ea80-7776-11eb-9b29-3075ac0e2aca.png)

![image](https://user-images.githubusercontent.com/1721533/109168526-d2b73380-7776-11eb-9e67-404b4d4328bc.png)

The controls for single tracks includes a timeline slider to allow users to move through an animation tracks timeline.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
