### PR TITLE
Get `Observer` type from NPM package

### DIFF
--- a/src/controls.tsx
+++ b/src/controls.tsx
@@ -1,3 +1,4 @@
+import { Observer } from '@playcanvas/observer';
 // @ts-ignore: library file import
 import Panel from '@playcanvas/pcui/Panel/component';
 // @ts-ignore: library file import
@@ -22,7 +23,7 @@ import SelectInput from '@playcanvas/pcui/SelectInput/component';
 import BindingTwoWay from '@playcanvas/pcui/BindingTwoWay';
 // @ts-ignore: library file import
 import React, { useEffect, useState, useContext } from 'react';
-import { Morph, Option, Observer, HierarchyNode } from './types';
+import { Morph, Option, HierarchyNode } from './types';
 
 const ObserverContext = React.createContext(null);
 const ObserverProvider = ObserverContext.Provider;

--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -1,8 +1,8 @@
+import { Observer } from '@playcanvas/observer';
 // @ts-ignore: library file import
 import InfoBox from '@playcanvas/pcui/InfoBox/component';
 // @ts-ignore: library file import
 import React, { useState } from 'react';
-import { Observer } from '@playcanvas/observer';
 
 const useObserverState = (observer: Observer, path: string) => {
     const parseFunc = (observerValue: any) => observerValue;

--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -2,7 +2,7 @@
 import InfoBox from '@playcanvas/pcui/InfoBox/component';
 // @ts-ignore: library file import
 import React, { useState } from 'react';
-import { Observer } from './types';
+import { Observer } from '@playcanvas/observer';
 
 const useObserverState = (observer: Observer, path: string) => {
     const parseFunc = (observerValue: any) => observerValue;

--- a/src/load-ui.tsx
+++ b/src/load-ui.tsx
@@ -1,3 +1,4 @@
+import { Observer } from '@playcanvas/observer';
 // @ts-ignore: library file import
 import Container from '@playcanvas/pcui/Container/component';
 // @ts-ignore: library file import
@@ -5,7 +6,7 @@ import Label from '@playcanvas/pcui/Label/component';
 // @ts-ignore: library file import
 import Button from '@playcanvas/pcui/Button/component';
 import React, { useRef } from 'react';
-import { Observer, File } from './types';
+import { File } from './types';
 
 const ObserverContext = React.createContext(null);
 const ObserverProvider = ObserverContext.Provider;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,13 +19,6 @@ export interface Skybox {
     label: string
 }
 
-export interface Observer {
-    set: (path: string, value: any, silent?: boolean, remote?: boolean, force?: boolean) => void,
-    get: (path: string) => any,
-    on: (eventName: string, callback: (value: any) => void) => void,
-    emit: (eventName: string) => void
-}
-
 export interface HierarchyNode {
     name: string,
     path: string,

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,3 +1,4 @@
+import { Observer } from '@playcanvas/observer';
 import * as pc from 'playcanvas';
 // @ts-ignore: No extras declarations
 import * as pcx from 'playcanvas/build/playcanvas-extras.js';
@@ -5,7 +6,7 @@ import DebugLines from './debug';
 // @ts-ignore: library file import
 import * as MeshoptDecoder from '../lib/meshopt_decoder.js';
 import { getAssetPath } from './helpers';
-import { Morph, File, Observer, HierarchyNode } from './types';
+import { Morph, File, HierarchyNode } from './types';
 // @ts-ignore: library file import
 import * as VoxParser from 'playcanvas/scripts/parsers/vox-parser.js';
 


### PR DESCRIPTION
The viewer source was declaring its own type declaration for `Observer` despite the typings being present in the `@playcanvas/observer` NPM package.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
