### PR TITLE
fix: Fix the baseHref for loading lodepng correctly

### DIFF
--- a/src/png-exporter.ts
+++ b/src/png-exporter.ts
@@ -82,7 +82,8 @@ class PngExporter {
             receiver(message);
         });
 
-        const baseHref = new URL('.', window.location.href).toString();
+        const url = new URL(window.location.href);
+        const baseHref = url.origin + url.pathname;
         this.worker.postMessage({ type: 'init', baseHref });
 
         this.receiveCallback = (resolve) => {


### PR DESCRIPTION
Follow up to #344 

Issue is that the `viewer` directory was unintentionally stripped out, i.e. we need to load this file: 
* (Expected) https://playcanvas.com/viewerstatic/lib/lodepng/lodepng.js
* (What happened after my previous PR; 404) https://playcanvas.com/static/lib/lodepng/lodepng.js

Using `url.origin` + `url.pathname` should give us the correct expected path when hosted under /viewer.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
