### PR TITLE
[FIX] Fix glTF min/mag filter settings not being respected

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1069,11 +1069,11 @@ class Viewer {
         return new Promise((resolve, reject) => {
             // provide buffer view callback so we can handle models compressed with MeshOptimizer
             // https://github.com/zeux/meshoptimizer
-            const processBufferView = function (
+            const processBufferView = (
                 gltfBuffer: any,
                 buffers: Array<any>,
                 continuation: (err: string, result: any) => void
-            ) {
+            ) => {
                 if (gltfBuffer.extensions && gltfBuffer.extensions.EXT_meshopt_compression) {
                     const extensionDef = gltfBuffer.extensions.EXT_meshopt_compression;
 
@@ -1105,7 +1105,7 @@ class Viewer {
                 }
             };
 
-            const processImage = function (gltfImage: any, continuation: (err: string, result: any) => void) {
+            const processImage = (gltfImage: any, continuation: (err: string, result: any) => void) => {
                 const u: File = externalUrls.find((url) => {
                     return url.filename === decodeURIComponent(path.normalize(gltfImage.uri || ''));
                 });
@@ -1133,7 +1133,7 @@ class Viewer {
                 }
             };
 
-            const processBuffer = function (gltfBuffer: any, continuation: (err: string, result: any) => void) {
+            const processBuffer = (gltfBuffer: any, continuation: (err: string, result: any) => void) => {
                 const u = externalUrls.find((url) => {
                     return url.filename === decodeURIComponent(path.normalize(gltfBuffer.uri || ''));
                 });
@@ -1155,16 +1155,16 @@ class Viewer {
             const containerAsset = new Asset(gltfUrl.filename, 'container', gltfUrl, null, {
                 // @ts-ignore TODO no definition in pc
                 bufferView: {
-                    processAsync: processBufferView.bind(this)
+                    processAsync: processBufferView
                 },
                 image: {
-                    processAsync: processImage.bind(this)
+                    processAsync: processImage
                 },
                 texture: {
                     postprocess: postProcessTexture
                 },
                 buffer: {
-                    processAsync: processBuffer.bind(this)
+                    processAsync: processBuffer
                 }
             });
             containerAsset.on('load', () => resolve(containerAsset));


### PR DESCRIPTION
Textures with `NEAREST` filtering specified in glTF samplers were appearing with linear filtering instead. This was caused by the model-viewer unconditionally setting max anisotropy on all textures before the glTF sampler settings were applied.

https://github.com/user-attachments/assets/b05bcf72-58fe-4483-a90a-d803025421ef

Fixes #323

## Changes

- Moved texture post-processing from `image.postprocess` to `texture.postprocess` callback
- Anisotropy is now only applied to textures that use linear filtering modes
- Textures with `NEAREST` min/mag filters now correctly display pixelated sampling

## Technical Details

The root cause was a timing issue in the glTF loading pipeline:

1. Previously, `image.postprocess` was setting `anisotropy = maxAnisotropy` on all textures
2. This callback runs in `createImages`, **before** `applySampler` is called in `createTextures`
3. While this shouldn't directly cause linear filtering, moving to `texture.postprocess` ensures we can check the actual filter mode after samplers are applied

The fix uses `texture.postprocess` which is called after `applySampler` sets the filter modes from the glTF sampler. This allows us to conditionally apply anisotropy only when appropriate:

```typescript
const postProcessTexture = (gltfTexture: any, textureAsset: Asset) => {
    const texture = textureAsset.resource as Texture;
    if (texture.minFilter !== FILTER_NEAREST && texture.magFilter !== FILTER_NEAREST) {
        texture.anisotropy = this.app.graphicsDevice.maxAnisotropy;
    }
};
```

Anisotropic filtering is only meaningful with linear filtering modes, so skipping it for `NEAREST` filtered textures is both semantically correct and ensures the glTF sampler settings are respected.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
