### PR TITLE
Use loaded scene filename to name downloaded PNG

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1030,7 +1030,11 @@ class Viewer {
         let filename = 'model-viewer';
         if (filenames && filenames.length > 0) {
             // remove extension from the first loaded model's filename
-            filename = filenames[0].replace(/\.[^/.]+$/, '');
+            const baseName = filenames[0].replace(/\.[^/.]+$/, '');
+            // ensure we have a valid filename after removing extension
+            if (baseName) {
+                filename = baseName;
+            }
         }
 
         // request a frame render and wait for it to complete (including resolve for MSAA)


### PR DESCRIPTION
Improve screenshot download functionality

- Screenshot filename now uses the loaded model's name instead of the generic "model-viewer.png" (e.g., loading `DamagedHelmet.glb` produces `DamagedHelmet.png`)
- Falls back to "model-viewer.png" when no model is loaded
- Fixed timing issue on WebGPU where screenshots were captured before the frame was rendered, resulting in blank images

The fix ensures a frame is rendered and the render target is resolved (for MSAA) before reading the texture data.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
