### PR TITLE
[FIX] Show all animations even when they have duplicate names

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1810,6 +1810,24 @@ class Viewer {
 
     // rebuild the animation state graph
     private rebuildAnimTracks() {
+        // Build unique display names for animations (handle duplicate names)
+        const nameCounts = new Map<string, number>();
+        this.animTracks.forEach((t: any) => {
+            nameCounts.set(t.name, (nameCounts.get(t.name) ?? 0) + 1);
+        });
+
+        // If there are duplicates, append index to make names unique
+        const nameIndices = new Map<string, number>();
+        const uniqueDisplayNames: string[] = this.animTracks.map((t: any) => {
+            const name = t.name;
+            if (nameCounts.get(name) > 1) {
+                const index = nameIndices.get(name) ?? 0;
+                nameIndices.set(name, index + 1);
+                return `${name} (${index + 1})`;
+            }
+            return name;
+        });
+
         this.entities.forEach((entity) => {
             // create the anim component if there isn't one already
             if (!entity.anim) {
@@ -1834,7 +1852,8 @@ class Viewer {
                 ]);
                 const path = `track_${i}`;
                 entity.anim.assignAnimation(path, t);
-                this.animationMap[t.name] = path;
+                // Use unique display name as key to avoid overwriting animations with the same name
+                this.animationMap[uniqueDisplayNames[i]] = path;
             });
             // if the user has selected to play all tracks in succession, then transition to the next track after a set amount of loops
             entity.anim.on('transition', (e) => {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1810,6 +1810,8 @@ class Viewer {
 
     // rebuild the animation state graph
     private rebuildAnimTracks() {
+        // reset animation map to avoid stale entries when rebuilding
+        this.animationMap = {};
         // Build unique display names for animations (handle duplicate names)
         const nameCounts = new Map<string, number>();
         this.animTracks.forEach((t: any) => {


### PR DESCRIPTION
Fixes #89

https://github.com/user-attachments/assets/6d681110-8b61-4699-b58d-300674c59b4f

## Description

When loading multiple animations with the same take name (e.g., from Mixamo), only one animation was shown in the animation dropdown. This happened because `animationMap` used the animation name as a key, causing duplicate names to overwrite each other.

## Changes

- Modified `rebuildAnimTracks()` to detect duplicate animation names
- Animations with duplicate names now display with a numbered suffix (e.g., "mixamo.com (1)", "mixamo.com (2)")
- Unique animation names remain unchanged

## Example

**Before:** Loading two animations both named "mixamo.com" showed only one entry in the dropdown.

**After:** Both animations are now visible as "mixamo.com (1)" and "mixamo.com (2)".

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
