### PR TITLE
chore: migrate to ESLint config v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Type-check
+        run: npm run typecheck
+
       - name: Build PlayCanvas Model Viewer
         run: npm run build
 
@@ -43,6 +46,9 @@ jobs:
 
       - name: Install Dependencies
         run: npm ci
+
+      - name: Check Formatting
+        run: npm run fmt
 
       - name: Run ESLint
         run: npm run lint

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,33 +1,24 @@
-import playcanvasConfig from '@playcanvas/eslint-config';
-import tsPlugin from '@typescript-eslint/eslint-plugin';
-import tsParser from '@typescript-eslint/parser';
+import reactConfig from '@playcanvas/eslint-config/react';
+import typescriptConfig from '@playcanvas/eslint-config/typescript';
 import globals from 'globals';
+import tseslint from 'typescript-eslint';
 
 export default [
-    ...playcanvasConfig,
+    ...typescriptConfig,
+    ...reactConfig,
     {
+        // /typescript only wires the TS parser for **/*.{js,mjs,ts}; this app also has .tsx
         files: ['**/*.ts', '**/*.tsx'],
         languageOptions: {
-            parser: tsParser,
+            parser: tseslint.parser,
             globals: {
                 ...globals.browser
             }
         },
-        plugins: {
-            '@typescript-eslint': tsPlugin
-        },
-        settings: {
-            'import/resolver': {
-                typescript: {}
-            }
-        },
         rules: {
-            ...tsPlugin.configs.recommended.rules,
             '@typescript-eslint/ban-ts-comment': 'off',
             '@typescript-eslint/no-explicit-any': 'off',
-            '@typescript-eslint/no-unused-vars': 'off',
-            'jsdoc/require-param-type': 'off',
-            'jsdoc/require-returns-type': 'off'
+            '@typescript-eslint/no-unused-vars': 'off'
         }
     },
     {
@@ -38,7 +29,7 @@ export default [
             }
         },
         rules: {
-            'import/no-unresolved': 'off'
+            'import-x/no-unresolved': 'off'
         }
     }
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,13 @@
 import reactConfig from '@playcanvas/eslint-config/react';
 import typescriptConfig from '@playcanvas/eslint-config/typescript';
 import globals from 'globals';
-import tseslint from 'typescript-eslint';
 
 export default [
     ...typescriptConfig,
     ...reactConfig,
     {
-        // /typescript only wires the TS parser for **/*.{js,mjs,ts}; this app also has .tsx
         files: ['**/*.ts', '**/*.tsx'],
         languageOptions: {
-            parser: tseslint.parser,
             globals: {
                 ...globals.browser
             }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,6 @@ export default [
         },
         rules: {
             '@typescript-eslint/ban-ts-comment': 'off',
-            '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/no-unused-vars': 'off'
         }
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,14 +19,9 @@ export default [
         }
     },
     {
-        files: ['**/*.js', '**/*.mjs'],
-        languageOptions: {
-            globals: {
-                ...globals.node
-            }
-        },
+        files: ['src/types.ts'],
         rules: {
-            'import-x/no-unresolved': 'off'
+            '@typescript-eslint/consistent-type-definitions': 'off'
         }
     }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "5.10.0",
             "license": "MIT",
             "devDependencies": {
-                "@playcanvas/eslint-config": "2.1.0",
+                "@playcanvas/eslint-config": "3.0.0-beta.8",
                 "@playcanvas/observer": "1.7.1",
                 "@playcanvas/pcui": "5.8.0",
                 "@rollup/plugin-alias": "6.0.0",
@@ -22,14 +22,12 @@
                 "@rollup/plugin-typescript": "12.1.4",
                 "@types/react": "19.2.17",
                 "@types/react-dom": "19.2.3",
-                "@typescript-eslint/eslint-plugin": "8.61.1",
-                "@typescript-eslint/parser": "8.61.1",
                 "concurrently": "9.2.1",
                 "cross-env": "10.1.0",
                 "eslint": "9.39.4",
-                "eslint-import-resolver-typescript": "4.4.5",
                 "globals": "17.6.0",
                 "playcanvas": "2.19.7",
+                "prettier": "^3.6.2",
                 "qrious": "4.0.2",
                 "react": "19.2.7",
                 "react-dom": "19.2.7",
@@ -42,6 +40,286 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@altano/repository-tools": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@altano/repository-tools/-/repository-tools-2.0.5.tgz",
+            "integrity": "sha512-dG0CH69cWUKaXOrfIdhldDt8zB3Tp4OQNVvnOWIS0wL+MiIkjyJC3WLFZGrO2r5anW00DxbDnEhpNHIkGCoNuw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/compat-data": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+            "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.8",
+                "@babel/types": "^7.29.8",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.8"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+            "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.8",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.8",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.8",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@emnapi/core": {
@@ -86,20 +364,40 @@
             "license": "MIT"
         },
         "node_modules/@es-joy/jsdoccomment": {
-            "version": "0.50.2",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
-            "integrity": "sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==",
+            "version": "0.78.0",
+            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.78.0.tgz",
+            "integrity": "sha512-rQkU5u8hNAq2NVRzHnIUUvR6arbO0b6AOlvpTNS48CkiKSn/xtNfOzBK23JE4SiW89DgvU7GtxLVgV4Vn2HBAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "^1.0.6",
-                "@typescript-eslint/types": "^8.11.0",
+                "@types/estree": "^1.0.8",
+                "@typescript-eslint/types": "^8.46.4",
                 "comment-parser": "1.4.1",
                 "esquery": "^1.6.0",
-                "jsdoc-type-pratt-parser": "~4.1.0"
+                "jsdoc-type-pratt-parser": "~7.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20.11.0"
+            }
+        },
+        "node_modules/@es-joy/jsdoccomment/node_modules/jsdoc-type-pratt-parser": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.0.0.tgz",
+            "integrity": "sha512-c7YbokssPOSHmqTbSAmTtnVgAVa/7lumWNYqomgd5KOMyPrRve2anx6lonfOsXEQacqF9FKVUj7bLg4vRSvdYA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@es-joy/resolve.exports": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+            "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -364,6 +662,17 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
@@ -744,18 +1053,42 @@
             }
         },
         "node_modules/@playcanvas/eslint-config": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-2.1.0.tgz",
-            "integrity": "sha512-m8IMRsdmxeSGvmfcl+wYk+dTF7I4wCbB+FozT//yMCUVCj7lHeaWWeHdouRUMgP5FWzEZ6q6u6bjXzOgUlbBeg==",
+            "version": "3.0.0-beta.8",
+            "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-3.0.0-beta.8.tgz",
+            "integrity": "sha512-E9GavHekFgxciZxcf0FHfn79uUT7aKRgxcFz/Pz7l5TszB1EqqNWI3Df0qcqFUSjnq6V1fvkgS1JraNXY0pK9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "eslint-plugin-import": "^2.31.0",
-                "eslint-plugin-jsdoc": "^50.6.11",
-                "eslint-plugin-regexp": "^2.7.0"
+                "@eslint/js": "^9.39.0",
+                "eslint-config-prettier": "^10.1.8",
+                "eslint-import-resolver-typescript": "^4.4.4",
+                "eslint-plugin-import-x": "^4.16.2",
+                "eslint-plugin-jsdoc": "^61.1.11",
+                "eslint-plugin-jsx-a11y": "^6.10.2",
+                "eslint-plugin-package-json": "^0.59.1",
+                "eslint-plugin-react": "^7.37.5",
+                "eslint-plugin-react-hooks": "^7.0.1",
+                "eslint-plugin-regexp": "^2.10.0",
+                "globals": "^16.5.0",
+                "jsonc-eslint-parser": "^2.4.1",
+                "typescript-eslint": "^8.60.1"
             },
             "peerDependencies": {
-                "eslint": ">= 8"
+                "eslint": ">= 9",
+                "typescript": ">= 4"
+            }
+        },
+        "node_modules/@playcanvas/eslint-config/node_modules/globals": {
+            "version": "16.5.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+            "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@playcanvas/observer": {
@@ -1085,9 +1418,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1102,9 +1432,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1119,9 +1446,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1136,9 +1460,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1153,9 +1474,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1170,9 +1488,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1187,9 +1502,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1204,9 +1516,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1221,9 +1530,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1238,9 +1544,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1255,9 +1558,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1272,9 +1572,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1289,9 +1586,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1387,7 +1681,22 @@
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
+        "node_modules/@sindresorhus/base62": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+            "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.1",
@@ -1419,7 +1728,9 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@types/react": {
             "version": "19.2.17",
@@ -1456,17 +1767,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
-            "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+            "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.61.1",
-                "@typescript-eslint/type-utils": "8.61.1",
-                "@typescript-eslint/utils": "8.61.1",
-                "@typescript-eslint/visitor-keys": "8.61.1",
+                "@typescript-eslint/scope-manager": "8.66.0",
+                "@typescript-eslint/type-utils": "8.66.0",
+                "@typescript-eslint/utils": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -1479,22 +1790,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.61.1",
+                "@typescript-eslint/parser": "^8.66.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
-            "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+            "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.61.1",
-                "@typescript-eslint/types": "8.61.1",
-                "@typescript-eslint/typescript-estree": "8.61.1",
-                "@typescript-eslint/visitor-keys": "8.61.1",
+                "@typescript-eslint/scope-manager": "8.66.0",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1510,14 +1821,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
-            "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+            "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.61.1",
-                "@typescript-eslint/types": "^8.61.1",
+                "@typescript-eslint/tsconfig-utils": "^8.66.0",
+                "@typescript-eslint/types": "^8.66.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1532,14 +1843,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
-            "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+            "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.61.1",
-                "@typescript-eslint/visitor-keys": "8.61.1"
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1550,9 +1861,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
-            "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+            "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1567,15 +1878,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
-            "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+            "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.61.1",
-                "@typescript-eslint/typescript-estree": "8.61.1",
-                "@typescript-eslint/utils": "8.61.1",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0",
+                "@typescript-eslint/utils": "8.66.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -1592,9 +1903,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
-            "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+            "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1606,16 +1917,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
-            "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+            "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.61.1",
-                "@typescript-eslint/tsconfig-utils": "8.61.1",
-                "@typescript-eslint/types": "8.61.1",
-                "@typescript-eslint/visitor-keys": "8.61.1",
+                "@typescript-eslint/project-service": "8.66.0",
+                "@typescript-eslint/tsconfig-utils": "8.66.0",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -1634,16 +1945,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
-            "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+            "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.61.1",
-                "@typescript-eslint/types": "8.61.1",
-                "@typescript-eslint/typescript-estree": "8.61.1"
+                "@typescript-eslint/scope-manager": "8.66.0",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1658,13 +1969,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.61.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
-            "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+            "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.61.1",
+                "@typescript-eslint/types": "8.66.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -1972,9 +2283,9 @@
             "license": "MIT"
         },
         "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2140,6 +2451,16 @@
             "dev": true,
             "license": "Python-2.0"
         },
+        "node_modules/aria-query": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+            "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -2180,12 +2501,35 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/array.prototype.findlast": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+            "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.2",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0",
+                "es-shim-unscopables": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/array.prototype.findlastindex": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
             "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.4",
@@ -2240,6 +2584,23 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/array.prototype.tosorted": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+            "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.3",
+                "es-errors": "^1.3.0",
+                "es-shim-unscopables": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/arraybuffer.prototype.slice": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
@@ -2261,6 +2622,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/ast-types-flow": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+            "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/async-function": {
             "version": "1.0.0",
@@ -2286,6 +2654,26 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/axe-core": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+            "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/axobject-query": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+            "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/balanced-match": {
@@ -2316,6 +2704,19 @@
             ],
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.11.12",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+            "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
         },
         "node_modules/bl": {
             "version": "4.1.0",
@@ -2403,6 +2804,40 @@
                 "node": ">=8"
             }
         },
+        "node_modules/browserslist": {
+            "version": "4.28.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+            "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "baseline-browser-mapping": "^2.10.44",
+                "caniuse-lite": "^1.0.30001806",
+                "electron-to-chromium": "^1.5.393",
+                "node-releases": "^2.0.51",
+                "update-browserslist-db": "^1.2.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
         "node_modules/buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -2447,15 +2882,15 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "get-intrinsic": "^1.2.4",
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
                 "set-function-length": "^1.2.2"
             },
             "engines": {
@@ -2519,6 +2954,27 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
         "node_modules/canvas": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
@@ -2580,6 +3036,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/change-case": {
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+            "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/chokidar": {
             "version": "4.0.3",
@@ -2849,6 +3312,13 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/cross-env": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -2888,6 +3358,13 @@
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/damerau-levenshtein": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+            "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/data-view-buffer": {
             "version": "1.0.2",
@@ -3041,6 +3518,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/detect-indent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.2.tgz",
+            "integrity": "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/detect-libc": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3050,6 +3540,19 @@
             "optional": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/detect-newline": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-4.0.1.tgz",
+            "integrity": "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/doctrine": {
@@ -3087,6 +3590,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.401",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
+            "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -3106,9 +3616,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.24.1",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-            "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+            "version": "1.24.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+            "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3190,6 +3700,34 @@
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-iterator-helpers": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
+            "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.24.2",
+                "es-errors": "^1.3.0",
+                "es-set-tostringtag": "^2.1.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.3.0",
+                "globalthis": "^1.0.4",
+                "gopd": "^1.2.0",
+                "has-property-descriptors": "^1.0.2",
+                "has-proto": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "internal-slot": "^1.1.0",
+                "iterator.prototype": "^1.1.5",
+                "math-intrinsics": "^1.1.0"
+            },
             "engines": {
                 "node": ">= 0.4"
             }
@@ -3337,6 +3875,41 @@
                 }
             }
         },
+        "node_modules/eslint-config-prettier": {
+            "version": "10.1.8",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-config-prettier"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint-fix-utils": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-fix-utils/-/eslint-fix-utils-0.4.3.tgz",
+            "integrity": "sha512-EKzNhsNavV5DdkHVltHBM9TqfsonCmiUhOm1Ra97zo03M9IAx3wtM1eC27eWGMj/D3LrALmHHNe1QlQH1P7Nxw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@types/estree": ">=1",
+                "eslint": ">=8"
+            },
+            "peerDependenciesMeta": {
+                "@types/estree": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/eslint-import-context": {
             "version": "0.1.9",
             "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
@@ -3368,6 +3941,8 @@
             "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "debug": "^3.2.7",
                 "is-core-module": "^2.13.0",
@@ -3380,6 +3955,8 @@
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -3425,6 +4002,8 @@
             "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "debug": "^3.2.7"
             },
@@ -3443,6 +4022,8 @@
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -3453,6 +4034,8 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -3481,12 +4064,51 @@
                 "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
             }
         },
+        "node_modules/eslint-plugin-import-x": {
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.1.tgz",
+            "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "^8.56.0",
+                "comment-parser": "^1.4.1",
+                "debug": "^4.4.1",
+                "eslint-import-context": "^0.1.9",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.3 || ^10.1.2",
+                "semver": "^7.7.2",
+                "stable-hash-x": "^0.2.0",
+                "unrs-resolver": "^1.9.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-plugin-import-x"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/utils": "^8.56.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "eslint-import-resolver-node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/utils": {
+                    "optional": true
+                },
+                "eslint-import-resolver-node": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3498,6 +4120,8 @@
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -3508,6 +4132,8 @@
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -3521,33 +4147,261 @@
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
+            "optional": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/eslint-plugin-jsdoc": {
-            "version": "50.8.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
-            "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
+            "version": "61.7.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-61.7.1.tgz",
+            "integrity": "sha512-36DpldF95MlTX//n3/naULFVt8d1cV4jmSkx7ZKrE9ikkKHAgMLesuWp1SmwpVwAs5ndIM6abKd6PeOYZUgdWg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@es-joy/jsdoccomment": "~0.50.2",
+                "@es-joy/jsdoccomment": "~0.78.0",
+                "@es-joy/resolve.exports": "1.2.0",
                 "are-docs-informative": "^0.0.2",
                 "comment-parser": "1.4.1",
-                "debug": "^4.4.1",
+                "debug": "^4.4.3",
                 "escape-string-regexp": "^4.0.0",
-                "espree": "^10.3.0",
-                "esquery": "^1.6.0",
+                "espree": "^11.0.0",
+                "esquery": "^1.7.0",
+                "html-entities": "^2.6.0",
+                "object-deep-merge": "^2.0.0",
                 "parse-imports-exports": "^0.2.4",
-                "semver": "^7.7.2",
-                "spdx-expression-parse": "^4.0.0"
+                "semver": "^7.7.3",
+                "spdx-expression-parse": "^4.0.0",
+                "to-valid-identifier": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20.11.0"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+            "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.16.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^5.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-plugin-jsx-a11y": {
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+            "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "aria-query": "^5.3.2",
+                "array-includes": "^3.1.8",
+                "array.prototype.flatmap": "^1.3.2",
+                "ast-types-flow": "^0.0.8",
+                "axe-core": "^4.10.0",
+                "axobject-query": "^4.1.0",
+                "damerau-levenshtein": "^1.0.8",
+                "emoji-regex": "^9.2.2",
+                "hasown": "^2.0.2",
+                "jsx-ast-utils": "^3.3.5",
+                "language-tags": "^1.0.9",
+                "minimatch": "^3.1.2",
+                "object.fromentries": "^2.0.8",
+                "safe-regex-test": "^1.0.3",
+                "string.prototype.includes": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependencies": {
+                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+            }
+        },
+        "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/eslint-plugin-package-json": {
+            "version": "0.59.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-0.59.1.tgz",
+            "integrity": "sha512-dalsU3Zsz8RYLkV6FnNBJh408WlTuqQaDfxV/ae29yK7pTzjNNJN+kqU9YhHfHkbJ5XBax4xHWvidvAk4xE31w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@altano/repository-tools": "^2.0.1",
+                "change-case": "^5.4.4",
+                "detect-indent": "^7.0.2",
+                "detect-newline": "^4.0.1",
+                "eslint-fix-utils": "~0.4.0",
+                "package-json-validator": "~0.31.0",
+                "semver": "^7.7.3",
+                "sort-object-keys": "^2.0.0",
+                "sort-package-json": "^3.4.0",
+                "validate-npm-package-name": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.0.0",
+                "jsonc-eslint-parser": "^2.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-react": {
+            "version": "7.37.5",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+            "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-includes": "^3.1.8",
+                "array.prototype.findlast": "^1.2.5",
+                "array.prototype.flatmap": "^1.3.3",
+                "array.prototype.tosorted": "^1.1.4",
+                "doctrine": "^2.1.0",
+                "es-iterator-helpers": "^1.2.1",
+                "estraverse": "^5.3.0",
+                "hasown": "^2.0.2",
+                "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+                "minimatch": "^3.1.2",
+                "object.entries": "^1.1.9",
+                "object.fromentries": "^2.0.8",
+                "object.values": "^1.2.1",
+                "prop-types": "^15.8.1",
+                "resolve": "^2.0.0-next.5",
+                "semver": "^6.3.1",
+                "string.prototype.matchall": "^4.0.12",
+                "string.prototype.repeat": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "peerDependencies": {
+                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+            }
+        },
+        "node_modules/eslint-plugin-react-hooks": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+            "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.24.4",
+                "@babel/parser": "^7.24.4",
+                "hermes-parser": "^0.25.1",
+                "zod": "^3.25.0 || ^4.0.0",
+                "zod-validation-error": "^3.5.0 || ^4.0.0"
             },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/resolve": {
+            "version": "2.0.0-next.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+            "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.2",
+                "node-exports-info": "^1.6.0",
+                "object-keys": "^1.1.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/eslint-plugin-regexp": {
@@ -3681,9 +4535,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -3979,6 +4833,16 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3987,6 +4851,19 @@
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-intrinsic": {
@@ -4070,6 +4947,16 @@
             },
             "funding": {
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+            }
+        },
+        "node_modules/git-hooks-list": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-4.2.1.tgz",
+            "integrity": "sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
             }
         },
         "node_modules/github-from-package": {
@@ -4218,9 +5105,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4229,6 +5116,40 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/hermes-estree": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+            "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/hermes-parser": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+            "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hermes-estree": "0.25.1"
+            }
+        },
+        "node_modules/html-entities": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+            "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/mdevils"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://patreon.com/mdevils"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
@@ -4431,13 +5352,13 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.2"
+                "hasown": "^2.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4625,6 +5546,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-port-reachable": {
@@ -4835,6 +5769,31 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/iterator.prototype": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+            "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-object-atoms": "^1.0.0",
+                "get-intrinsic": "^1.2.6",
+                "get-proto": "^1.0.0",
+                "has-symbols": "^1.1.0",
+                "set-function-name": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/js-yaml": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -4856,6 +5815,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
+            }
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/json-buffer": {
@@ -4885,11 +5857,66 @@
             "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "minimist": "^1.2.0"
             },
             "bin": {
                 "json5": "lib/cli.js"
+            }
+        },
+        "node_modules/jsonc-eslint-parser": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+            "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.5.0",
+                "eslint-visitor-keys": "^3.0.0",
+                "espree": "^9.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            }
+        },
+        "node_modules/jsonc-eslint-parser/node_modules/espree": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.9.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/jsx-ast-utils": {
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+            "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-includes": "^3.1.6",
+                "array.prototype.flat": "^1.3.1",
+                "object.assign": "^4.1.4",
+                "object.values": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/keyv": {
@@ -4900,6 +5927,26 @@
             "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/language-subtag-registry": {
+            "version": "0.3.23",
+            "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+            "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/language-tags": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+            "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "language-subtag-registry": "^0.3.20"
+            },
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/levn": {
@@ -4938,6 +5985,29 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
@@ -5166,6 +6236,45 @@
             "license": "MIT",
             "optional": true
         },
+        "node_modules/node-exports-info": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+            "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array.prototype.flatmap": "^1.3.3",
+                "es-errors": "^1.3.0",
+                "object.entries": "^1.1.9",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-exports-info/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.52",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+            "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -5178,6 +6287,23 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-deep-merge": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+            "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
@@ -5223,6 +6349,22 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/object.entries": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+            "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/object.fromentries": {
             "version": "2.0.8",
             "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
@@ -5248,6 +6390,8 @@
             "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -5381,6 +6525,123 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/package-json-validator": {
+            "version": "0.31.0",
+            "resolved": "https://registry.npmjs.org/package-json-validator/-/package-json-validator-0.31.0.tgz",
+            "integrity": "sha512-kAVO0fNFWI2xpmthogYHnHjCtg0nJvwm9yjd9nnrR5OKIts5fmNMK2OhhjnLD1/ohJNodhCa5tZm8AolOgkfMg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.7.2",
+                "validate-npm-package-license": "^3.0.4",
+                "yargs": "~18.0.0"
+            },
+            "bin": {
+                "pjv": "lib/bin/pjv.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/package-json-validator/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/package-json-validator/node_modules/cliui": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/package-json-validator/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/package-json-validator/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/package-json-validator/node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/package-json-validator/node_modules/yargs": {
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^9.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "string-width": "^7.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^22.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/package-json-validator/node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5451,6 +6712,13 @@
             "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "4.0.3",
@@ -5528,6 +6796,34 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/prop-types": {
+            "version": "15.8.1",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
             }
         },
         "node_modules/pump": {
@@ -5643,6 +6939,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",
@@ -5787,6 +7090,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/reserved-identifiers": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+            "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/resolve": {
@@ -6379,6 +7695,35 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/sort-object-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-2.1.0.tgz",
+            "integrity": "sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/sort-package-json": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.7.1.tgz",
+            "integrity": "sha512-ssk1HG7whF8N/T1IsNAQrtHG5Cbdi0rAgRJZXYBr9hF5xaHnBNzUx/W6LcthEW7FhOwvZssbESZuO+GxssqAyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-indent": "^7.0.2",
+                "detect-newline": "^4.0.1",
+                "git-hooks-list": "^4.1.1",
+                "is-plain-obj": "^4.1.0",
+                "semver": "^7.7.3",
+                "sort-object-keys": "^2.0.1",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "sort-package-json": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6410,6 +7755,28 @@
                 "source-map": "^0.6.0"
             }
         },
+        "node_modules/spdx-correct": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
         "node_modules/spdx-exceptions": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
@@ -6429,9 +7796,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.22",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
             "dev": true,
             "license": "CC0-1.0"
         },
@@ -6486,6 +7853,60 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string.prototype.includes": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+            "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/string.prototype.matchall": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+            "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.6",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0",
+                "get-intrinsic": "^1.2.6",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "internal-slot": "^1.1.0",
+                "regexp.prototype.flags": "^1.5.3",
+                "set-function-name": "^2.0.2",
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.repeat": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+            "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
             }
         },
         "node_modules/string.prototype.trim": {
@@ -6569,6 +7990,8 @@
             "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -6707,6 +8130,23 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/to-valid-identifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+            "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/base62": "^1.0.0",
+                "reserved-identifiers": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/tree-kill": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -6736,6 +8176,8 @@
             "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/json5": "^0.0.29",
                 "json5": "^1.0.2",
@@ -6882,6 +8324,30 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/typescript-eslint": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+            "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.66.0",
+                "@typescript-eslint/parser": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0",
+                "@typescript-eslint/utils": "8.66.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
         "node_modules/unbox-primitive": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -6936,6 +8402,37 @@
                 "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
             }
         },
+        "node_modules/update-browserslist-db": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
         "node_modules/update-check": {
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
@@ -6964,6 +8461,38 @@
             "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/validate-npm-package-name": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
         },
         "node_modules/vary": {
             "version": "1.1.2",
@@ -7155,6 +8684,13 @@
                 "node": ">=10"
             }
         },
+        "node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/yargs": {
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -7240,6 +8776,29 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-validation-error": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+            "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.0 || ^4.0.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "url": "https://github.com/playcanvas/model-viewer.git"
     },
     "devDependencies": {
-        "@playcanvas/eslint-config": "2.1.0",
+        "@playcanvas/eslint-config": "3.0.0-beta.6",
         "@playcanvas/observer": "1.7.1",
         "@playcanvas/pcui": "5.8.0",
         "@rollup/plugin-alias": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "url": "https://github.com/playcanvas/model-viewer.git"
     },
     "devDependencies": {
-        "@playcanvas/eslint-config": "3.0.0-beta.6",
+        "@playcanvas/eslint-config": "3.0.0-beta.8",
         "@playcanvas/observer": "1.7.1",
         "@playcanvas/pcui": "5.8.0",
         "@rollup/plugin-alias": "6.0.0",
@@ -35,14 +35,12 @@
         "@rollup/plugin-typescript": "12.1.4",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
-        "@typescript-eslint/eslint-plugin": "8.61.1",
-        "@typescript-eslint/parser": "8.61.1",
         "concurrently": "9.2.1",
         "cross-env": "10.1.0",
         "eslint": "9.39.4",
-        "eslint-import-resolver-typescript": "4.4.5",
         "globals": "17.6.0",
         "playcanvas": "2.19.7",
+        "prettier": "^3.6.2",
         "qrious": "4.0.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -56,9 +54,12 @@
     "scripts": {
         "build": "rollup -c",
         "develop": "cross-env BUILD_TYPE=debug concurrently --kill-others \"npm run watch\" \"npm run serve\"",
-        "lint": "eslint src rollup.config.mjs eslint.config.mjs",
-        "lint:fix": "eslint src rollup.config.mjs eslint.config.mjs --fix",
+        "fmt": "prettier --check src rollup.config.mjs eslint.config.mjs prettier.config.mjs",
+        "fmt:fix": "prettier --write src rollup.config.mjs eslint.config.mjs prettier.config.mjs",
+        "lint": "eslint src rollup.config.mjs eslint.config.mjs prettier.config.mjs",
+        "lint:fix": "eslint src rollup.config.mjs eslint.config.mjs prettier.config.mjs --fix",
         "serve": "serve --cors dist",
+        "typecheck": "tsc",
         "watch": "rollup -c -w"
     },
     "engines": {

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@playcanvas/eslint-config/prettier';

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,7 +16,9 @@ import { copyAndWatch } from './plugins/copy-and-watch.mjs';
 
 // debug, profile, release
 const BUILD_TYPE = process.env.BUILD_TYPE || 'release';
-const ENGINE_DIR = path.resolve(`node_modules/playcanvas/build/playcanvas${BUILD_TYPE === 'debug' ? '.dbg' : ''}/src/index.js`);
+const ENGINE_DIR = path.resolve(
+    `node_modules/playcanvas/build/playcanvas${BUILD_TYPE === 'debug' ? '.dbg' : ''}/src/index.js`
+);
 
 const BLUE_OUT = '\x1b[34m';
 const BOLD_OUT = '\x1b[1m';
@@ -27,16 +29,19 @@ const title = [
     'Building PlayCanvas Model Viewer',
     `type ${BOLD_OUT}${BUILD_TYPE}${REGULAR_OUT}`,
     `engine ${BOLD_OUT}${ENGINE_DIR}${REGULAR_OUT}`
-].map(l => `${BLUE_OUT}${l}`).join('\n');
+]
+    .map((l) => `${BLUE_OUT}${l}`)
+    .join('\n');
 console.log(`${BLUE_OUT}${title}${RESET_OUT}\n`);
 
 const TARGETS = [
     {
         src: 'src/index.html',
         transform: (contents) => {
-            return contents.toString()
-            .replace('__BASE_HREF__', process.env.BASE_HREF || '')
-            .replace('__');
+            return contents
+                .toString()
+                .replace('__BASE_HREF__', process.env.BASE_HREF || '')
+                .replace('__');
         }
     },
     { src: 'src/manifest.json' },
@@ -77,7 +82,7 @@ export default {
         image({ dom: true }),
         alias({
             entries: {
-                'playcanvas': ENGINE_DIR
+                playcanvas: ENGINE_DIR
             }
         }),
         commonjs(),
@@ -86,11 +91,12 @@ export default {
             tsconfig: './tsconfig.json'
         }),
         json(),
-        (BUILD_TYPE !== 'debug') && terser({
-            mangle: {
-                // script classes can't be mangeled
-                reserved: ['CameraControls']
-            }
-        })
+        BUILD_TYPE !== 'debug' &&
+            terser({
+                mangle: {
+                    // script classes can't be mangeled
+                    reserved: ['CameraControls']
+                }
+            })
     ]
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,23 @@ import {
 } from 'playcanvas';
 
 class App extends AppBase {
-    constructor(canvas: HTMLCanvasElement, options: any) {
+    constructor(
+        canvas: HTMLCanvasElement,
+        options: Pick<AppOptions, 'graphicsDevice'> &
+            Partial<
+                Pick<
+                    AppOptions,
+                    | 'elementInput'
+                    | 'keyboard'
+                    | 'mouse'
+                    | 'touch'
+                    | 'gamepads'
+                    | 'scriptPrefix'
+                    | 'assetPrefix'
+                    | 'scriptsOrder'
+                >
+            >
+    ) {
         super(canvas);
 
         const appOptions = new AppOptions();

--- a/src/camera-controls.ts
+++ b/src/camera-controls.ts
@@ -1,7 +1,6 @@
-import { type Observer } from '@playcanvas/observer';
+import type {Observer} from '@playcanvas/observer';
 import {
     math,
-    AppBase,
     DualGestureSource,
     FlyController,
     GamepadSource,
@@ -12,10 +11,12 @@ import {
     Pose,
     PROJECTION_PERSPECTIVE,
     Vec2,
-    Vec3,
-    type CameraComponent,
-    type InputController
+    Vec3
+    
+    
 } from 'playcanvas';
+import type {
+    AppBase,CameraComponent, InputController} from 'playcanvas';
 
 type CameraControlsState = {
     axis: Vec3;

--- a/src/camera-controls.ts
+++ b/src/camera-controls.ts
@@ -1,4 +1,4 @@
-import type {Observer} from '@playcanvas/observer';
+import type { Observer } from '@playcanvas/observer';
 import {
     math,
     DualGestureSource,
@@ -12,11 +12,8 @@ import {
     PROJECTION_PERSPECTIVE,
     Vec2,
     Vec3
-    
-    
 } from 'playcanvas';
-import type {
-    AppBase,CameraComponent, InputController} from 'playcanvas';
+import type { AppBase, CameraComponent, InputController } from 'playcanvas';
 
 type CameraControlsState = {
     axis: Vec3;
@@ -54,35 +51,19 @@ const screenToWorld = (camera: CameraComponent, dx: number, dy: number, dz: numb
     const { width, height } = system.app.graphicsDevice.clientRect;
 
     // normalize deltas to device coord space
-    out.set(
-        -(dx / width) * 2,
-        (dy / height) * 2,
-        0
-    );
+    out.set(-(dx / width) * 2, (dy / height) * 2, 0);
 
     // calculate half size of the view frustum at the current distance
     const halfSize = tmpV2.set(0, 0, 0);
     if (projection === PROJECTION_PERSPECTIVE) {
         const halfSlice = dz * Math.tan(0.5 * fov * math.DEG_TO_RAD);
         if (horizontalFov) {
-            halfSize.set(
-                halfSlice,
-                halfSlice / aspectRatio,
-                0
-            );
+            halfSize.set(halfSlice, halfSlice / aspectRatio, 0);
         } else {
-            halfSize.set(
-                halfSlice * aspectRatio,
-                halfSlice,
-                0
-            );
+            halfSize.set(halfSlice * aspectRatio, halfSlice, 0);
         }
     } else {
-        halfSize.set(
-            orthoHeight * aspectRatio,
-            orthoHeight,
-            0
-        );
+        halfSize.set(orthoHeight * aspectRatio, orthoHeight, 0);
     }
 
     // scale by device coord space
@@ -236,11 +217,13 @@ class CameraControls {
         applyDeadZone(rightStick, this.gamepadDeadZone.x, this.gamepadDeadZone.y);
 
         // update state
-        this._state.axis.add(tmpV1.set(
-            (key[keyCode.D] - key[keyCode.A]) + (key[keyCode.RIGHT] - key[keyCode.LEFT]),
-            (key[keyCode.E] - key[keyCode.Q]),
-            (key[keyCode.W] - key[keyCode.S]) + (key[keyCode.UP] - key[keyCode.DOWN])
-        ));
+        this._state.axis.add(
+            tmpV1.set(
+                key[keyCode.D] - key[keyCode.A] + (key[keyCode.RIGHT] - key[keyCode.LEFT]),
+                key[keyCode.E] - key[keyCode.Q],
+                key[keyCode.W] - key[keyCode.S] + (key[keyCode.UP] - key[keyCode.DOWN])
+            )
+        );
         for (let i = 0; i < this._state.mouse.length; i++) {
             this._state.mouse[i] += button[i];
         }

--- a/src/debug-lines.ts
+++ b/src/debug-lines.ts
@@ -1,3 +1,5 @@
+import type {
+    Entity} from 'playcanvas';
 import {
     BLEND_NORMAL,
     BUFFER_DYNAMIC,
@@ -12,7 +14,6 @@ import {
     TYPE_FLOAT32,
     TYPE_UINT8,
     DepthState,
-    Entity,
     GraphNode,
     Layer,
     Mesh,
@@ -25,7 +26,7 @@ import {
     VertexIterator
 } from 'playcanvas';
 
-import { App } from './app';
+import type { App } from './app';
 
 let debugLayerFront: Layer = null;
 let debugLayerBack: Layer = null;
@@ -308,7 +309,7 @@ class DebugLines {
         this.vertexCursor++;
     }
 
-    generateNormals(vertexBuffer: VertexBuffer, worldMat: Mat4, length: number, skinMatrices: Array<Mat4>) {
+    generateNormals(vertexBuffer: VertexBuffer, worldMat: Mat4, length: number, skinMatrices: Mat4[]) {
         const it = new VertexIterator(vertexBuffer);
         const positions = it.element[SEMANTIC_POSITION];
         const normals = it.element[SEMANTIC_NORMAL];

--- a/src/debug-lines.ts
+++ b/src/debug-lines.ts
@@ -1,5 +1,4 @@
-import type {
-    Entity} from 'playcanvas';
+import type { Entity } from 'playcanvas';
 import {
     BLEND_NORMAL,
     BUFFER_DYNAMIC,
@@ -37,21 +36,57 @@ const v2 = new Vec3();
 const up = new Vec3(0, 1, 0);
 const mat = new Mat4();
 const unitBone = [
-    [[0,    0,   0], [-0.5, 0, 0.3]],
-    [[0,    0,   0], [0.5,  0, 0.3]],
-    [[0,    0,   0], [0, -0.5, 0.3]],
-    [[0,    0,   0], [0,  0.5, 0.3]],
-    [[0,    0,   1], [-0.5, 0, 0.3]],
-    [[0,    0,   1], [0.5,  0, 0.3]],
-    [[0,    0,   1], [0, -0.5, 0.3]],
-    [[0,    0,   1], [0,  0.5, 0.3]],
-    [[0, -0.5, 0.3], [0.5,  0, 0.3]],
-    [[0.5,  0, 0.3], [0,  0.5, 0.3]],
-    [[0,  0.5, 0.3], [-0.5, 0, 0.3]],
-    [[-0.5, 0, 0.3], [0, -0.5, 0.3]]
+    [
+        [0, 0, 0],
+        [-0.5, 0, 0.3]
+    ],
+    [
+        [0, 0, 0],
+        [0.5, 0, 0.3]
+    ],
+    [
+        [0, 0, 0],
+        [0, -0.5, 0.3]
+    ],
+    [
+        [0, 0, 0],
+        [0, 0.5, 0.3]
+    ],
+    [
+        [0, 0, 1],
+        [-0.5, 0, 0.3]
+    ],
+    [
+        [0, 0, 1],
+        [0.5, 0, 0.3]
+    ],
+    [
+        [0, 0, 1],
+        [0, -0.5, 0.3]
+    ],
+    [
+        [0, 0, 1],
+        [0, 0.5, 0.3]
+    ],
+    [
+        [0, -0.5, 0.3],
+        [0.5, 0, 0.3]
+    ],
+    [
+        [0.5, 0, 0.3],
+        [0, 0.5, 0.3]
+    ],
+    [
+        [0, 0.5, 0.3],
+        [-0.5, 0, 0.3]
+    ],
+    [
+        [-0.5, 0, 0.3],
+        [0, -0.5, 0.3]
+    ]
 ];
 
-const vertexGLSL = /* glsl */`
+const vertexGLSL = /* glsl */ `
 attribute vec3 vertex_position;
 attribute vec4 vertex_color;
 
@@ -73,7 +108,7 @@ void main(void) {
     gl_Position.z = 0.0;
 }`;
 
-const fragmentGLSL = /* glsl */`
+const fragmentGLSL = /* glsl */ `
 precision highp float;
 
 varying vec2 zw;
@@ -87,7 +122,7 @@ void main(void) {
     gl_FragDepth = max(0.0, min(1.0, (zw.x / zw.y + 1.0) * 0.5));
 }`;
 
-const vertexWGSL = /* wgsl */`
+const vertexWGSL = /* wgsl */ `
 attribute vertex_position: vec3f;
 attribute vertex_color: vec4f;
 
@@ -114,7 +149,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
 }
 `;
 
-const fragmentWGSL = /* wgsl */`
+const fragmentWGSL = /* wgsl */ `
 varying zw: vec2f;
 varying vColor: vec4f;
 
@@ -334,11 +369,7 @@ class DebugLines {
                 // transform by skinning matrices
                 skinMat.copy(Mat4.ZERO);
                 for (let j = 0; j < 4; ++j) {
-                    DebugLines.matrixMad(
-                        skinMat,
-                        skinMatrices[blendIndices.get(j)],
-                        blendWeights.get(j)
-                    );
+                    DebugLines.matrixMad(skinMat, skinMatrices[blendIndices.get(j)], blendWeights.get(j));
                 }
                 skinMat.mul2(worldMat, skinMat);
                 skinMat.transformPoint(p0, p0);
@@ -396,7 +427,7 @@ class DebugLines {
     generateSkeleton(node: GraphNode, showBones: boolean, showAxes: boolean, selectedNode: GraphNode) {
         const recurse = (curr: GraphNode, selected: boolean) => {
             if (curr.enabled) {
-                selected ||= (curr === selectedNode);
+                selected ||= curr === selectedNode;
 
                 // render child links
                 for (let i = 0; i < curr.children.length; ++i) {
@@ -437,6 +468,4 @@ class DebugLines {
     }
 }
 
-export {
-    DebugLines
-};
+export { DebugLines };

--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -12,3 +12,8 @@ declare module '*.scss' {
     const value: string;
     export default value;
 }
+
+declare module 'qrious' {
+    const QRious: new (options: { element: HTMLCanvasElement; value: string; size: number }) => object;
+    export default QRious;
+}

--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -1,17 +1,14 @@
 declare module '*.png' {
-    const value: string;
+    const value: HTMLImageElement;
     export default value;
 }
 
 declare module '*.svg' {
-    const value: { src: string };
+    const value: HTMLImageElement;
     export default value;
 }
 
-declare module '*.scss' {
-    const value: string;
-    export default value;
-}
+declare module '*.scss' {}
 
 declare module 'qrious' {
     const QRious: new (options: { element: HTMLCanvasElement; value: string; size: number }) => object;

--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -1,14 +1,14 @@
 declare module '*.png' {
-    const value: any;
+    const value: string;
     export default value;
 }
 
 declare module '*.svg' {
-    const value: any;
+    const value: { src: string };
     export default value;
 }
 
 declare module '*.scss' {
-    const value: any;
+    const value: string;
     export default value;
 }

--- a/src/drop-handler.ts
+++ b/src/drop-handler.ts
@@ -1,15 +1,15 @@
 import { path } from 'playcanvas';
 
-interface File {
+type File = {
     url: string,
     filename?: string
 }
 
-type DropHandlerFunc = (files: Array<File>, resetScene: boolean) => void;
+type DropHandlerFunc = (files: File[], resetScene: boolean) => void;
 
-const resolveDirectories = (entries: Array<FileSystemEntry>): Promise<Array<FileSystemFileEntry>> => {
-    const promises: Promise<Array<FileSystemFileEntry>>[] = [];
-    const result: Array<FileSystemFileEntry> = [];
+const resolveDirectories = (entries: FileSystemEntry[]): Promise<FileSystemFileEntry[]> => {
+    const promises: Promise<FileSystemFileEntry[]>[] = [];
+    const result: FileSystemFileEntry[] = [];
 
     entries.forEach((entry) => {
         if (entry.isFile) {
@@ -21,13 +21,13 @@ const resolveDirectories = (entries: Array<FileSystemEntry>): Promise<Array<File
                 const p: Promise<any>[] = [];
 
                 const read = () => {
-                    reader.readEntries((children: Array<FileSystemEntry>) => {
+                    reader.readEntries((children: FileSystemEntry[]) => {
                         if (children.length > 0) {
                             p.push(resolveDirectories(children));
                             read();
                         } else {
                             Promise.all(p)
-                            .then((children: Array<Array<FileSystemFileEntry>>) => {
+                            .then((children: FileSystemFileEntry[][]) => {
                                 resolve(children.flat());
                             });
                         }
@@ -39,12 +39,12 @@ const resolveDirectories = (entries: Array<FileSystemEntry>): Promise<Array<File
     });
 
     return Promise.all(promises)
-    .then((children: Array<Array<FileSystemFileEntry>>) => {
+    .then((children: FileSystemFileEntry[][]) => {
         return result.concat(...children);
     });
 };
 
-const removeCommonPrefix = (urls: Array<File>) => {
+const removeCommonPrefix = (urls: File[]) => {
     const split = (pathname: string) => {
         const parts = pathname.split(path.delimiter);
         const base = parts[0];
@@ -90,7 +90,7 @@ const CreateDropHandler = (target: HTMLElement, dropHandler: DropHandlerFunc) =>
             .map(item => item.webkitGetAsEntry());
 
         resolveDirectories(entries)
-        .then((entries: Array<FileSystemFileEntry>) => {
+        .then((entries: FileSystemFileEntry[]) => {
             return Promise.all(entries.map((entry) => {
                 return new Promise((resolve) => {
                     entry.file((entryFile: any) => {
@@ -102,7 +102,7 @@ const CreateDropHandler = (target: HTMLElement, dropHandler: DropHandlerFunc) =>
                 });
             }));
         })
-        .then((files: Array<File>) => {
+        .then((files: File[]) => {
             if (files.length > 1) {
                 removeCommonPrefix(files);
             }

--- a/src/drop-handler.ts
+++ b/src/drop-handler.ts
@@ -16,10 +16,10 @@ const resolveDirectories = (entries: FileSystemEntry[]): Promise<FileSystemFileE
             result.push(entry as FileSystemFileEntry);
         } else if (entry.isDirectory) {
             promises.push(
-                new Promise<any>((resolve) => {
+                new Promise<FileSystemFileEntry[]>((resolve) => {
                     const reader = (entry as FileSystemDirectoryEntry).createReader();
 
-                    const p: Promise<any>[] = [];
+                    const p: Promise<FileSystemFileEntry[]>[] = [];
 
                     const read = () => {
                         reader.readEntries((children: FileSystemEntry[]) => {
@@ -102,7 +102,7 @@ const CreateDropHandler = (target: HTMLElement, dropHandler: DropHandlerFunc) =>
                     return Promise.all(
                         entries.map((entry) => {
                             return new Promise((resolve) => {
-                                entry.file((entryFile: any) => {
+                                entry.file((entryFile: globalThis.File) => {
                                     resolve({
                                         url: URL.createObjectURL(entryFile),
                                         filename: entry.fullPath.substring(1)

--- a/src/drop-handler.ts
+++ b/src/drop-handler.ts
@@ -1,9 +1,9 @@
 import { path } from 'playcanvas';
 
 type File = {
-    url: string,
-    filename?: string
-}
+    url: string;
+    filename?: string;
+};
 
 type DropHandlerFunc = (files: File[], resetScene: boolean) => void;
 
@@ -15,31 +15,31 @@ const resolveDirectories = (entries: FileSystemEntry[]): Promise<FileSystemFileE
         if (entry.isFile) {
             result.push(entry as FileSystemFileEntry);
         } else if (entry.isDirectory) {
-            promises.push(new Promise<any>((resolve) => {
-                const reader = (entry as FileSystemDirectoryEntry).createReader();
+            promises.push(
+                new Promise<any>((resolve) => {
+                    const reader = (entry as FileSystemDirectoryEntry).createReader();
 
-                const p: Promise<any>[] = [];
+                    const p: Promise<any>[] = [];
 
-                const read = () => {
-                    reader.readEntries((children: FileSystemEntry[]) => {
-                        if (children.length > 0) {
-                            p.push(resolveDirectories(children));
-                            read();
-                        } else {
-                            Promise.all(p)
-                            .then((children: FileSystemFileEntry[][]) => {
-                                resolve(children.flat());
-                            });
-                        }
-                    });
-                };
-                read();
-            }));
+                    const read = () => {
+                        reader.readEntries((children: FileSystemEntry[]) => {
+                            if (children.length > 0) {
+                                p.push(resolveDirectories(children));
+                                read();
+                            } else {
+                                Promise.all(p).then((children: FileSystemFileEntry[][]) => {
+                                    resolve(children.flat());
+                                });
+                            }
+                        });
+                    };
+                    read();
+                })
+            );
         }
     });
 
-    return Promise.all(promises)
-    .then((children: FileSystemFileEntry[][]) => {
+    return Promise.all(promises).then((children: FileSystemFileEntry[][]) => {
         return result.concat(...children);
     });
 };
@@ -70,45 +70,57 @@ const removeCommonPrefix = (urls: File[]) => {
 
 // configure drag and drop
 const CreateDropHandler = (target: HTMLElement, dropHandler: DropHandlerFunc) => {
-    target.addEventListener('dragstart', (ev) => {
-        ev.preventDefault();
-        ev.stopPropagation();
-        ev.dataTransfer.effectAllowed = 'all';
-    }, false);
+    target.addEventListener(
+        'dragstart',
+        (ev) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            ev.dataTransfer.effectAllowed = 'all';
+        },
+        false
+    );
 
-    target.addEventListener('dragover', (ev) => {
-        ev.preventDefault();
-        ev.stopPropagation();
-        ev.dataTransfer.effectAllowed = 'all';
-    }, false);
+    target.addEventListener(
+        'dragover',
+        (ev) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            ev.dataTransfer.effectAllowed = 'all';
+        },
+        false
+    );
 
-    target.addEventListener('drop', (ev) => {
-        ev.preventDefault();
+    target.addEventListener(
+        'drop',
+        (ev) => {
+            ev.preventDefault();
 
-        const entries =
-            Array.from(ev.dataTransfer.items)
-            .map(item => item.webkitGetAsEntry());
+            const entries = Array.from(ev.dataTransfer.items).map((item) => item.webkitGetAsEntry());
 
-        resolveDirectories(entries)
-        .then((entries: FileSystemFileEntry[]) => {
-            return Promise.all(entries.map((entry) => {
-                return new Promise((resolve) => {
-                    entry.file((entryFile: any) => {
-                        resolve({
-                            url: URL.createObjectURL(entryFile),
-                            filename: entry.fullPath.substring(1)
-                        });
-                    });
+            resolveDirectories(entries)
+                .then((entries: FileSystemFileEntry[]) => {
+                    return Promise.all(
+                        entries.map((entry) => {
+                            return new Promise((resolve) => {
+                                entry.file((entryFile: any) => {
+                                    resolve({
+                                        url: URL.createObjectURL(entryFile),
+                                        filename: entry.fullPath.substring(1)
+                                    });
+                                });
+                            });
+                        })
+                    );
+                })
+                .then((files: File[]) => {
+                    if (files.length > 1) {
+                        removeCommonPrefix(files);
+                    }
+                    dropHandler(files, !ev.shiftKey);
                 });
-            }));
-        })
-        .then((files: File[]) => {
-            if (files.length > 1) {
-                removeCommonPrefix(files);
-            }
-            dropHandler(files, !ev.shiftKey);
-        });
-    }, false);
+        },
+        false
+    );
 };
 
 export { CreateDropHandler, File };

--- a/src/dummy-webgpu.ts
+++ b/src/dummy-webgpu.ts
@@ -1,4 +1,4 @@
-import { AppBase } from 'playcanvas';
+import type { AppBase } from 'playcanvas';
 
 class DummyWebGPU {
     constructor(app: AppBase) {

--- a/src/dummy-webgpu.ts
+++ b/src/dummy-webgpu.ts
@@ -29,7 +29,13 @@ class DummyWebGPU {
             console.log('Created WebGPU device used for profiling');
 
             // Create a WebGPU context for the new canvas
-            const context = canvas.getContext('webgpu') as any;
+            const context = canvas.getContext('webgpu' as never) as unknown as {
+                configure: (options: {
+                    device: Awaited<ReturnType<typeof adapter.requestDevice>>;
+                    format: string;
+                }) => void;
+                getCurrentTexture: () => { createView: () => unknown };
+            };
 
             // Configure the WebGPU context
             context.configure({ device, format: 'bgra8unorm' });

--- a/src/dummy-webgpu.ts
+++ b/src/dummy-webgpu.ts
@@ -1,5 +1,6 @@
 import type { AppBase } from 'playcanvas';
 
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class -- preserve constructor api
 class DummyWebGPU {
     constructor(app: AppBase) {
         if (app.graphicsDevice.isWebGPU) {
@@ -45,12 +46,14 @@ class DummyWebGPU {
 
                 // Create a render pass descriptor with a red background
                 const renderPassDescriptor = {
-                    colorAttachments: [{
-                        view: textureView,
-                        clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },  // Red background
-                        loadOp: 'clear',
-                        storeOp: 'store'
-                    }]
+                    colorAttachments: [
+                        {
+                            view: textureView,
+                            clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 }, // Red background
+                            loadOp: 'clear',
+                            storeOp: 'store'
+                        }
+                    ]
                 };
 
                 // render pass

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -26,10 +26,9 @@ const addEventListenerOnClickOnly = (element: any, callback: any, delta = 2) => 
 
 // extract members of the object given a list of paths to extract
 const extract = (obj: any, paths: string[]) => {
-
     const resolve = (obj: any, path: string[]) => {
         for (const p of path) {
-            if (!obj.hasOwnProperty(p)) {
+            if (!Object.prototype.hasOwnProperty.call(obj, p)) {
                 return null;
             }
             obj = obj[p];
@@ -37,7 +36,7 @@ const extract = (obj: any, paths: string[]) => {
         return obj;
     };
 
-    const result: any = { };
+    const result: any = {};
 
     for (const pathString of paths) {
         const path = pathString.split('.');
@@ -47,8 +46,8 @@ const extract = (obj: any, paths: string[]) => {
         for (let i = 0; i < path.length; ++i) {
             const p = path[i];
             if (i < path.length - 1) {
-                if (!parent.hasOwnProperty(p)) {
-                    parent[p] = { };
+                if (!Object.prototype.hasOwnProperty.call(parent, p)) {
+                    parent[p] = {};
                 }
                 parent = parent[p];
             } else {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,14 +1,14 @@
-const addEventListenerOnClickOnly = (element: any, callback: any, delta = 2) => {
+const addEventListenerOnClickOnly = (element: HTMLElement, callback: (event: MouseEvent) => void, delta = 2) => {
     let startX: number;
     let startY: number;
 
-    const mouseDownEvt = (event: any) => {
+    const mouseDownEvt = (event: MouseEvent) => {
         startX = event.pageX;
         startY = event.pageY;
     };
     element.addEventListener('mousedown', mouseDownEvt);
 
-    const mouseUpEvt = (event: any) => {
+    const mouseUpEvt = (event: MouseEvent) => {
         const diffX = Math.abs(event.pageX - startX);
         const diffY = Math.abs(event.pageY - startY);
 
@@ -25,31 +25,31 @@ const addEventListenerOnClickOnly = (element: any, callback: any, delta = 2) => 
 };
 
 // extract members of the object given a list of paths to extract
-const extract = (obj: any, paths: string[]) => {
-    const resolve = (obj: any, path: string[]) => {
+const extract = <T extends object>(obj: T, paths: string[]) => {
+    const resolve = (obj: object, path: string[]) => {
         for (const p of path) {
-            if (!Object.prototype.hasOwnProperty.call(obj, p)) {
+            if (!Reflect.apply(obj.hasOwnProperty, obj, [p])) {
                 return null;
             }
-            obj = obj[p];
+            obj = (obj as Record<string, unknown>)[p] as object;
         }
         return obj;
     };
 
-    const result: any = {};
+    const result: Record<string, unknown> = {};
 
     for (const pathString of paths) {
         const path = pathString.split('.');
         const value = resolve(obj, path);
 
-        let parent = result;
+        let parent: Record<string, unknown> = result;
         for (let i = 0; i < path.length; ++i) {
             const p = path[i];
             if (i < path.length - 1) {
-                if (!Object.prototype.hasOwnProperty.call(parent, p)) {
+                if (!Reflect.apply(parent.hasOwnProperty, parent, [p])) {
                     parent[p] = {};
                 }
-                parent = parent[p];
+                parent = parent[p] as Record<string, unknown>;
             } else {
                 parent[p] = value;
             }

--- a/src/index.html
+++ b/src/index.html
@@ -1,20 +1,23 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-    <title>Model Viewer</title>
-    <meta charset="utf-8" />
-    <base href="__BASE_HREF__" />
-    <meta name="description" content="Fast and lightweight glTF 2.0 and gaussian splatting PLY viewer powered by the PlayCanvas engine." />
-    <meta name="keywords" content="glTF, GLB, PLY, WebGL, WebGPU, PlayCanvas, Viewer, Gaussian Splatting" />
-    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0" />
-    <link rel="icon" type="image/png" href="static/playcanvas-logo.png" />
-    <link rel="stylesheet" href="style.css" />
-    <link rel="manifest" href="manifest.json" />
-</head>
+    <head>
+        <title>Model Viewer</title>
+        <meta charset="utf-8" />
+        <base href="__BASE_HREF__" />
+        <meta
+            name="description"
+            content="Fast and lightweight glTF 2.0 and gaussian splatting PLY viewer powered by the PlayCanvas engine."
+        />
+        <meta name="keywords" content="glTF, GLB, PLY, WebGL, WebGPU, PlayCanvas, Viewer, Gaussian Splatting" />
+        <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0" />
+        <link rel="icon" type="image/png" href="static/playcanvas-logo.png" />
+        <link rel="stylesheet" href="style.css" />
+        <link rel="manifest" href="manifest.json" />
+    </head>
 
-<body>
-    <a id='ar-link' rel='ar' download='asset.usdz'><img /></a>
-    <div id='app'></div>
-    <script src="index.js"></script>
-</body>
+    <body>
+        <a id="ar-link" rel="ar" download="asset.usdz"><img /></a>
+        <div id="app"></div>
+        <script src="index.js"></script>
+    </body>
 </html>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,8 +13,10 @@ import { initMaterials } from './material';
 import { ObserverData } from './types';
 import initializeUI from './ui';
 import Viewer from './viewer';
+
 import './style.scss';
 import { version as modelViewerVersion } from '../package.json';
+
 import { DummyWebGPU } from './dummy-webgpu';
 
 // Permit some additional properties to be set on the window

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import {
     version as engineVersion,
     revision as engineRevision
 } from 'playcanvas';
+import type * as pc from 'playcanvas';
 
 import { version as modelViewerVersion } from '../package.json';
 
@@ -30,9 +31,9 @@ declare global {
         launchQueue: {
             setConsumer: (callback: (launchParams: LaunchParams) => void) => void;
         };
-        pc: any;
+        pc: typeof pc;
         viewer: Viewer;
-        webkit?: any;
+        webkit?: { messageHandlers?: object };
     }
 }
 
@@ -175,7 +176,7 @@ const observerData: ObserverData = {
 };
 
 const saveOptions = (observer: Observer, name: string) => {
-    const options = observer.json() as any;
+    const options = observer.json() as ObserverData;
     window.localStorage.setItem(
         `model-viewer-${name}`,
         JSON.stringify({
@@ -192,17 +193,17 @@ const saveOptions = (observer: Observer, name: string) => {
 const loadOptions = (observer: Observer, name: string, skyboxUrls: Map<string, string>) => {
     const filter = ['skybox.options', 'debug.renderMode'];
 
-    const loadRec = (path: string, value: any) => {
+    const loadRec = (path: string, value: unknown) => {
         if (filter.indexOf(path) !== -1) {
             return;
         }
 
         if (typeof value === 'object') {
-            Object.keys(value).forEach((k) => {
-                loadRec(path ? `${path}.${k}` : k, value[k]);
+            Object.keys(value as object).forEach((k) => {
+                loadRec(path ? `${path}.${k}` : k, (value as Record<string, unknown>)[k]);
             });
         } else {
-            if (path !== 'skybox.value' || value === 'None' || skyboxUrls.has(value)) {
+            if (path !== 'skybox.value' || value === 'None' || skyboxUrls.has(value as string)) {
                 observer.set(path, value);
             }
         }
@@ -293,7 +294,7 @@ const main = () => {
         const files: { url: string; filename: string }[] = [];
 
         // handle OS-based file association in PWA mode
-        const promises: Promise<any>[] = [];
+        const promises: Promise<void>[] = [];
         if ('launchQueue' in window) {
             window.launchQueue.setConsumer((launchParams: LaunchParams) => {
                 for (const fileHandle of launchParams.files) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,21 +9,23 @@ import {
     revision as engineRevision
 } from 'playcanvas';
 
+import { version as modelViewerVersion } from '../package.json';
+
+import { DummyWebGPU } from './dummy-webgpu';
 import { initMaterials } from './material';
-import { ObserverData } from './types';
+import type { ObserverData } from './types';
 import initializeUI from './ui';
 import Viewer from './viewer';
 
 import './style.scss';
-import { version as modelViewerVersion } from '../package.json';
-
-import { DummyWebGPU } from './dummy-webgpu';
 
 // Permit some additional properties to be set on the window
 declare global {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- declaration merging
     interface LaunchParams {
         readonly files: FileSystemFileHandle[];
     }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- declaration merging
     interface Window {
         launchQueue: {
             setConsumer: (callback: (launchParams: LaunchParams) => void) => void;
@@ -36,7 +38,7 @@ declare global {
 
 const skyboxes = [
     { label: 'Abandoned Tank Farm', url: './skybox/abandoned_tank_farm_01_2k.hdr' },
-    { label: 'Adam\'s Place Bridge', url: './skybox/adams_place_bridge_2k.hdr' },
+    { label: "Adam's Place Bridge", url: './skybox/adams_place_bridge_2k.hdr' },
     { label: 'Artist Workshop', url: './skybox/artist_workshop_2k.hdr' },
     { label: 'Ballroom', url: './skybox/ballroom_2k.hdr' },
     { label: 'Circus Arena', url: './skybox/circus_arena_2k.hdr' },
@@ -76,7 +78,7 @@ const observerData: ObserverData = {
     },
     skybox: {
         value: 'Paul Lobe Haus',
-        options: JSON.stringify(['None'].concat(skyboxes.map(s => s.label)).map(l => ({ v: l, t: l }))),
+        options: JSON.stringify(['None'].concat(skyboxes.map((s) => s.label)).map((l) => ({ v: l, t: l }))),
         exposure: 0,
         rotation: 0,
         background: 'Infinite Sphere',
@@ -174,20 +176,23 @@ const observerData: ObserverData = {
 
 const saveOptions = (observer: Observer, name: string) => {
     const options = observer.json() as any;
-    window.localStorage.setItem(`model-viewer-${name}`, JSON.stringify({
-        camera: options.camera,
-        skybox: options.skybox,
-        light: options.light,
-        debug: options.debug,
-        shadowCatcher: options.shadowCatcher,
-        enableWebGPU: options.enableWebGPU
-    }));
+    window.localStorage.setItem(
+        `model-viewer-${name}`,
+        JSON.stringify({
+            camera: options.camera,
+            skybox: options.skybox,
+            light: options.light,
+            debug: options.debug,
+            shadowCatcher: options.shadowCatcher,
+            enableWebGPU: options.enableWebGPU
+        })
+    );
 };
 
 const loadOptions = (observer: Observer, name: string, skyboxUrls: Map<string, string>) => {
     const filter = ['skybox.options', 'debug.renderMode'];
 
-    const loadRec = (path: string, value:any) => {
+    const loadRec = (path: string, value: any) => {
         if (filter.indexOf(path) !== -1) {
             return;
         }
@@ -207,12 +212,16 @@ const loadOptions = (observer: Observer, name: string, skyboxUrls: Map<string, s
     if (options) {
         try {
             loadRec('', JSON.parse(options));
-        } catch { }
+        } catch {
+            // ignore invalid saved options
+        }
     }
 };
 
 // print out versions of dependent packages
-console.log(`Model Viewer v${modelViewerVersion} | PCUI v${pcuiVersion} (${pcuiRevision}) | PlayCanvas Engine v${engineVersion} (${engineRevision})`);
+console.log(
+    `Model Viewer v${modelViewerVersion} | PCUI v${pcuiVersion} (${pcuiRevision}) | PlayCanvas Engine v${engineVersion} (${engineRevision})`
+);
 
 const main = () => {
     // initialize the apps state
@@ -236,7 +245,7 @@ const main = () => {
         fallbackUrl: 'static/lib/draco/draco.js'
     });
 
-    const skyboxUrls = new Map(skyboxes.map(s => [s.label, `static/${s.url}`]));
+    const skyboxUrls = new Map(skyboxes.map((s) => [s.label, `static/${s.url}`]));
 
     // hide / show spinner when loading files
     observer.on('ui.spinner:set', (value: boolean) => {
@@ -281,7 +290,7 @@ const main = () => {
         window.viewer = viewer;
 
         // get list of files, decode them
-        const files: { url: string, filename: string }[] = [];
+        const files: { url: string; filename: string }[] = [];
 
         // handle OS-based file association in PWA mode
         const promises: Promise<any>[] = [];

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,27 +6,34 @@
     "start_url": "/",
     "scope": "/",
     "background_color": "#000000",
-    "icons": [{
-        "src": "static/playcanvas-logo.png",
-        "sizes": "512x512",
-        "type": "image/png"
-    }],
-    "screenshots": [{
-        "src": "static/screenshot-wide.png",
-        "sizes": "3004x2060",
-        "type": "image/png",
-        "form_factor": "wide"
-    }, {
-        "src": "static/screenshot-narrow.png",
-        "sizes": "1392x2786",
-        "type": "image/png",
-        "form_factor": "narrow"
-    }],
-    "file_handlers": [{
-        "action": "/",
-        "accept": {
-            "application/ply": [".ply"],
-            "model/gltf-binary": [".glb"]
+    "icons": [
+        {
+            "src": "static/playcanvas-logo.png",
+            "sizes": "512x512",
+            "type": "image/png"
         }
-    }]
+    ],
+    "screenshots": [
+        {
+            "src": "static/screenshot-wide.png",
+            "sizes": "3004x2060",
+            "type": "image/png",
+            "form_factor": "wide"
+        },
+        {
+            "src": "static/screenshot-narrow.png",
+            "sizes": "1392x2786",
+            "type": "image/png",
+            "form_factor": "narrow"
+        }
+    ],
+    "file_handlers": [
+        {
+            "action": "/",
+            "accept": {
+                "application/ply": [".ply"],
+                "model/gltf-binary": [".glb"]
+            }
+        }
+    ]
 }

--- a/src/material.ts
+++ b/src/material.ts
@@ -1,8 +1,14 @@
 import { BLEND_NONE, BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE_MINUS_SRC_ALPHA, Material } from 'playcanvas';
 
-let setBlendTypeOrig: any;
+type BlendMaterial = Material & {
+    _blendState: {
+        setAlphaBlend: (equation: number, source: number, destination: number) => void;
+    };
+};
 
-function setBlendType(type: number) {
+let setBlendTypeOrig: (this: Material, type: number) => void;
+
+function setBlendType(this: BlendMaterial, type: number) {
     // set engine function
     setBlendTypeOrig.call(this, type);
 

--- a/src/material.ts
+++ b/src/material.ts
@@ -1,10 +1,4 @@
-import {
-    BLEND_NONE,
-    BLENDEQUATION_ADD,
-    BLENDMODE_ONE,
-    BLENDMODE_ONE_MINUS_SRC_ALPHA,
-    Material
-} from 'playcanvas';
+import { BLEND_NONE, BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE_MINUS_SRC_ALPHA, Material } from 'playcanvas';
 
 let setBlendTypeOrig: any;
 
@@ -42,6 +36,4 @@ const initMaterials = () => {
     });
 };
 
-export {
-    initMaterials
-};
+export { initMaterials };

--- a/src/multiframe.ts
+++ b/src/multiframe.ts
@@ -1,3 +1,8 @@
+import type {
+    CameraComponent,
+    ScopeSpace,
+    Shader,
+    GraphicsDevice} from 'playcanvas';
 import {
     BLENDEQUATION_ADD,
     BLENDMODE_CONSTANT,
@@ -10,15 +15,11 @@ import {
     PIXELFORMAT_RGBA32F,
     SEMANTIC_POSITION,
     BlendState,
-    CameraComponent,
     RenderPassShaderQuad,
     RenderTarget,
-    ScopeSpace,
-    Shader,
     ShaderUtils,
     Texture,
     Vec3,
-    GraphicsDevice,
     EventHandler
 } from 'playcanvas';
 

--- a/src/multiframe.ts
+++ b/src/multiframe.ts
@@ -112,7 +112,7 @@ class CustomRenderPass extends RenderPassShaderQuad {
     }
 }
 
-const resolve = (scope: ScopeSpace, values: any) => {
+const resolve = (scope: ScopeSpace, values: Record<string, unknown>) => {
     for (const key in values) {
         scope.resolve(key).setValue(values[key]);
     }

--- a/src/multiframe.ts
+++ b/src/multiframe.ts
@@ -1,8 +1,4 @@
-import type {
-    CameraComponent,
-    ScopeSpace,
-    Shader,
-    GraphicsDevice} from 'playcanvas';
+import type { CameraComponent, ScopeSpace, Shader, GraphicsDevice } from 'playcanvas';
 import {
     BLENDEQUATION_ADD,
     BLENDMODE_CONSTANT,
@@ -45,7 +41,7 @@ const fragmentGLSL = `
     }
 `;
 
-const vertexWGSL = /* wgsl */`
+const vertexWGSL = /* wgsl */ `
     attribute vertex_position: vec2f;
 
     varying texcoord: vec2f;
@@ -63,7 +59,7 @@ const vertexWGSL = /* wgsl */`
     }
 `;
 
-const fragmentWGSL = /* wgsl */`
+const fragmentWGSL = /* wgsl */ `
     varying texcoord: vec2f;
 
     var multiframeTex: texture_2d<f32>;
@@ -92,9 +88,11 @@ const supportsFloat32 = (device: GraphicsDevice): boolean => {
 
 // lighting source should be stored HDR
 const choosePixelFormat = (device: GraphicsDevice): number => {
-    return supportsFloat16(device) ? PIXELFORMAT_RGBA16F :
-        supportsFloat32(device) ? PIXELFORMAT_RGBA32F :
-            PIXELFORMAT_RGBA8;
+    return supportsFloat16(device)
+        ? PIXELFORMAT_RGBA16F
+        : supportsFloat32(device)
+          ? PIXELFORMAT_RGBA32F
+          : PIXELFORMAT_RGBA8;
 };
 
 // calculate 1d gauss
@@ -258,7 +256,7 @@ class Multiframe {
             resolve(device.scope, {
                 texcoordMod: !blending && device.isWebGPU ? [1, -1, 0, 1] : [1, 1, 0, 0],
                 multiframeTex: blending ? this.accumTexture : this.sourceTex,
-                power: blending ? (1.0 / gamma) : 1.0
+                power: blending ? 1.0 / gamma : 1.0
             });
         });
 
@@ -295,7 +293,10 @@ class Multiframe {
         const samples: Vec3[] = [];
         const kernelSize = Math.ceil(3 * sigma) + 1;
         const halfSize = size * 0.5;
-        let sx, sy, weight, totalWeight = 0;
+        let sx,
+            sy,
+            weight,
+            totalWeight = 0;
 
         // generate jittered grid samples (poisson would be better)
         for (let x = 0; x < numSamples; ++x) {
@@ -309,7 +310,7 @@ class Multiframe {
                     sy = (y / (numSamples - 1)) * 2.0 - 1.0;
                 }
                 // calculate sample weight
-                weight = (sigma <= 0.0) ? 1.0 : gauss(sx * kernelSize, sigma) * gauss(sy * kernelSize, sigma);
+                weight = sigma <= 0.0 ? 1.0 : gauss(sx * kernelSize, sigma) * gauss(sy * kernelSize, sigma);
                 totalWeight += weight;
                 samples.push(new Vec3(sx * halfSize, sy * halfSize, weight));
             }
@@ -324,7 +325,7 @@ class Multiframe {
         samples.sort((a, b) => {
             const aL = a.length();
             const bL = b.length();
-            return aL < bL ? -1 : (bL < aL ? 1 : 0);
+            return aL < bL ? -1 : bL < aL ? 1 : 0;
         });
 
         return samples;
@@ -374,6 +375,4 @@ class Multiframe {
     }
 }
 
-export {
-    Multiframe
-};
+export { Multiframe };

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -1,9 +1,5 @@
-import {
-    type AppBase,
-    type Entity,
-    Picker as EnginePicker,
-    Vec3
-} from 'playcanvas';
+import { Picker as EnginePicker } from 'playcanvas';
+import type { AppBase, Entity, Vec3 } from 'playcanvas';
 
 const pickerScale = 0.25;
 

--- a/src/png-exporter.ts
+++ b/src/png-exporter.ts
@@ -1,19 +1,37 @@
 class PngExporter {
     static WORKER_STR = function () {
+        type LodePng = {
+            _malloc: (size: number) => number;
+            _free: (pointer: number) => void;
+            _lodepng_encode32: (
+                resultData: number,
+                resultSize: number,
+                imageData: number,
+                width: number,
+                height: number
+            ) => void;
+            HEAPU8: Uint8Array;
+            HEAPU32: Uint32Array;
+        };
+        type Scope = typeof self & {
+            __baseHref: string;
+            importScripts: (url: string) => void;
+            lodepng: (options: { locateFile: () => string }) => LodePng | PromiseLike<LodePng>;
+        };
         const initLodepng = () => {
             // This function will be invoked after receiving the base href via an 'init' message
-            return new Promise((resolve) => {
-                const baseHref = (self as any).__baseHref as string;
-                (self as any).importScripts(`${baseHref}static/lib/lodepng/lodepng.js`);
+            return new Promise<LodePng>((resolve) => {
+                const baseHref = (self as unknown as Scope).__baseHref;
+                (self as unknown as Scope).importScripts(`${baseHref}static/lib/lodepng/lodepng.js`);
                 resolve(
-                    (self as any).lodepng({
+                    (self as unknown as Scope).lodepng({
                         locateFile: () => `${baseHref}static/lib/lodepng/lodepng.wasm`
                     })
                 );
             });
         };
 
-        const compress = (lodepng: any, words: any[], width: number, height: number): Uint8Array => {
+        const compress = (lodepng: LodePng, words: Uint32Array, width: number, height: number): Uint8Array => {
             const resultDataPtrPtr = lodepng._malloc(4);
             const resultSizePtr = lodepng._malloc(4);
             const imageData = lodepng._malloc(width * height * 4);
@@ -44,13 +62,13 @@ class PngExporter {
         };
 
         const main = () => {
-            let lodepngPromise: Promise<any> | null = null;
+            let lodepngPromise: Promise<LodePng> | null = null;
 
             self.onmessage = async (message) => {
                 const data = message.data;
 
                 if (data && data.type === 'init') {
-                    (self as any).__baseHref = data.baseHref as string;
+                    (self as unknown as Scope).__baseHref = data.baseHref as string;
                     lodepngPromise = initLodepng();
                     return;
                 }
@@ -74,7 +92,7 @@ class PngExporter {
 
     worker: Worker;
 
-    receiveCallback: (resolve: (result: Uint8Array) => void) => void;
+    receiveCallback: (resolve: (result: Uint8Array<ArrayBuffer>) => void) => void;
 
     constructor() {
         let receiver: (message: MessageEvent) => void = null;
@@ -100,7 +118,7 @@ class PngExporter {
     }
 
     // download the data uri
-    _downloadFile(filename: string, data: any) {
+    _downloadFile(filename: string, data: Uint8Array<ArrayBuffer>) {
         const blob = new Blob([data], { type: 'octet/stream' });
         const url = window.URL.createObjectURL(blob);
 

--- a/src/png-exporter.ts
+++ b/src/png-exporter.ts
@@ -5,9 +5,11 @@ class PngExporter {
             return new Promise((resolve) => {
                 const baseHref = (self as any).__baseHref as string;
                 (self as any).importScripts(`${baseHref}static/lib/lodepng/lodepng.js`);
-                resolve((self as any).lodepng({
-                    locateFile: () => `${baseHref}static/lib/lodepng/lodepng.wasm`
-                }));
+                resolve(
+                    (self as any).lodepng({
+                        locateFile: () => `${baseHref}static/lib/lodepng/lodepng.wasm`
+                    })
+                );
             });
         };
 
@@ -29,7 +31,10 @@ class PngExporter {
             lodepng._lodepng_encode32(resultDataPtrPtr, resultSizePtr, imageData, width, height);
 
             // read results
-            const result = lodepng.HEAPU8.slice(lodepng.HEAPU32[resultDataPtrPtr / 4], lodepng.HEAPU32[resultDataPtrPtr / 4] + lodepng.HEAPU32[resultSizePtr / 4]);
+            const result = lodepng.HEAPU8.slice(
+                lodepng.HEAPU32[resultDataPtrPtr / 4],
+                lodepng.HEAPU32[resultDataPtrPtr / 4] + lodepng.HEAPU32[resultSizePtr / 4]
+            );
 
             lodepng._free(resultDataPtrPtr);
             lodepng._free(resultSizePtr);
@@ -108,16 +113,17 @@ class PngExporter {
     }
 
     async export(filename: string, words: Uint32Array, width: number, height: number) {
-        this.worker.postMessage({
-            type: 'encode',
-            words: words,
-            width: width,
-            height: height
-        }, [words.buffer]);
+        this.worker.postMessage(
+            {
+                type: 'encode',
+                words: words,
+                width: width,
+                height: height
+            },
+            [words.buffer]
+        );
         this._downloadFile(filename, await new Promise(this.receiveCallback));
     }
 }
 
-export {
-    PngExporter
-};
+export { PngExporter };

--- a/src/shadow-catcher.ts
+++ b/src/shadow-catcher.ts
@@ -1,14 +1,15 @@
+import type {
+    AppBase,
+    BoundingBox,
+    CameraComponent,
+    MeshInstance,
+    RenderComponent} from 'playcanvas';
 import {
     BLEND_PREMULTIPLIED,
     SHADOW_VSM_16F,
     SHADOWUPDATE_REALTIME as SHADOWUPDATE,
-    AppBase,
-    BoundingBox,
-    CameraComponent,
     Entity,
     Layer,
-    MeshInstance,
-    RenderComponent,
     StandardMaterial
 } from 'playcanvas';
 

--- a/src/shadow-catcher.ts
+++ b/src/shadow-catcher.ts
@@ -1,9 +1,4 @@
-import type {
-    AppBase,
-    BoundingBox,
-    CameraComponent,
-    MeshInstance,
-    RenderComponent} from 'playcanvas';
+import type { AppBase, BoundingBox, CameraComponent, MeshInstance, RenderComponent } from 'playcanvas';
 import {
     BLEND_PREMULTIPLIED,
     SHADOW_VSM_16F,
@@ -102,11 +97,9 @@ class ShadowCatcher {
 
     onEntityRemoved(entity: Entity) {
         entity.findComponents('render').forEach((component: RenderComponent) => {
-            this.layer.shadowCasters = this.layer.shadowCasters.filter(
-                (meshInstance: MeshInstance) => {
-                    return component.meshInstances.indexOf(meshInstance) === -1;
-                }
-            );
+            this.layer.shadowCasters = this.layer.shadowCasters.filter((meshInstance: MeshInstance) => {
+                return component.meshInstances.indexOf(meshInstance) === -1;
+            });
         });
     }
 
@@ -139,6 +132,4 @@ class ShadowCatcher {
     }
 }
 
-export {
-    ShadowCatcher
-};
+export { ShadowCatcher };

--- a/src/style.scss
+++ b/src/style.scss
@@ -68,7 +68,7 @@ body {
     font-size: 14px;
     margin-right: 10px;
     text-align: center;
-    color: #FAD961;
+    color: #fad961;
     position: absolute;
     left: 33%;
     top: 67%;
@@ -76,7 +76,7 @@ body {
 }
 
 .pcui-panel.pcui-collapsible > .pcui-panel-header:before {
-    color: #FAD961 !important;
+    color: #fad961 !important;
 }
 
 #panel-toggle:hover::before {
@@ -177,7 +177,7 @@ input {
 }
 
 .header span {
-    color: #b1b8ba;;
+    color: #b1b8ba;
 }
 
 .pcui-infobox {
@@ -296,7 +296,8 @@ input {
     left: 20px;
 }
 
-.download-button::before, .fullscreen-button::before {
+.download-button::before,
+.fullscreen-button::before {
     font-size: 16px !important;
 }
 
@@ -353,7 +354,8 @@ input {
     width: 100%;
 }
 
-.scene-hierarchy-panel, .selected-node-panel {
+.scene-hierarchy-panel,
+.selected-node-panel {
     border: 1px solid rgb(41, 53, 56);
 }
 
@@ -407,7 +409,7 @@ input {
 
 .load-button-panel {
     width: 500px;
-    background-color: #28282880;;
+    background-color: #28282880;
     padding: 0px 16px 16px 16px;
     border-radius: 0;
     font-size: 16px;
@@ -425,7 +427,7 @@ input {
 #drag-drop {
     height: 145px;
     background-color: #28282840;
-    border: 1px dashed #FFFFFF;
+    border: 1px dashed #ffffff;
     display: block;
     display: flex;
     align-items: center;
@@ -626,7 +628,6 @@ input {
 }
 
 .panel-value-boolean {
-    
 }
 
 .morph-label {
@@ -678,7 +679,6 @@ input {
 }
 
 @media only screen and (max-width: 950px) {
-
     #panel-left.collapsed {
         overflow: visible !important;
     }
@@ -764,7 +764,7 @@ input {
     position: fixed;
 }
 
-#panel-left:not(.collapsed)> #panel-toggle > img {
+#panel-left:not(.collapsed) > #panel-toggle > img {
     display: none;
 }
 
@@ -831,7 +831,8 @@ input {
 @keyframes animation-spin {
     from {
         transform: rotate(0deg);
-    } to {
+    }
+    to {
         transform: rotate(360deg);
     }
 }
@@ -843,7 +844,8 @@ input {
     top: calc(50% - 15px);
 }
 
-#panel-left.collapsed #scene-container, #panel-left.collapsed .header {
+#panel-left.collapsed #scene-container,
+#panel-left.collapsed .header {
     display: none !important;
 }
 
@@ -922,7 +924,9 @@ input {
     opacity: 0 !important;
 }
 
-.pcui-label, .pcui-button, .pcui-text-input {
+.pcui-label,
+.pcui-button,
+.pcui-text-input {
     color: white !important;
     font-size: 12px !important;
     font-weight: 400 !important;
@@ -937,6 +941,9 @@ input {
     color: #aaaaaa !important;
 }
 
-.pcui-select-input:not(.pcui-disabled):not(.pcui-readonly) .pcui-select-input-list > *:hover, .pcui-select-input:not(.pcui-disabled):not(.pcui-readonly) .pcui-select-input-list > .pcui-select-input-label-highlighted {
+.pcui-select-input:not(.pcui-disabled):not(.pcui-readonly) .pcui-select-input-list > *:hover,
+.pcui-select-input:not(.pcui-disabled):not(.pcui-readonly)
+    .pcui-select-input-list
+    > .pcui-select-input-label-highlighted {
     background-color: $bcg-primary;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,31 +1,31 @@
-export interface MorphTargetData {
+export type MorphTargetData = {
     name: string,
     targetIndex: number,
     weight?: number
 }
 
-export interface File {
+export type File = {
     url: string,
     filename?: string
 }
 
-export interface Option {
+export type Option = {
     v: string | number | null,
     t: string
 }
 
-export interface HierarchyNode {
+export type HierarchyNode = {
     name: string,
     path: string,
-    children: Array<HierarchyNode>
+    children: HierarchyNode[]
 }
 
-export interface SceneCamera {
+export type SceneCamera = {
     name: string,
     path: string
 }
 
-export interface ObserverData {
+export type ObserverData = {
     ui: {
         fullscreen: boolean,
         active?: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,7 +142,7 @@ export interface ObserverData {
         primitiveCount?: number;
         textureVRAM?: number;
         meshVRAM?: number;
-        bounds?: any;
+        bounds?: string;
         variant: {
             selected: number;
         };
@@ -171,4 +171,7 @@ export interface ObserverData {
     centerScene: boolean;
 }
 
-export type SetProperty = (path: string, value: any) => void;
+export type PropertyValue =
+    string | number | boolean | string[] | { r: number; g: number; b: number } | ObserverData['animation'] | null;
+
+export type SetProperty = (path: string, value: PropertyValue) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,160 +1,174 @@
-export type MorphTargetData = {
-    name: string,
-    targetIndex: number,
-    weight?: number
+export interface MorphTargetData {
+    name: string;
+    targetIndex: number;
+    weight?: number;
 }
 
-export type File = {
-    url: string,
-    filename?: string
+export interface File {
+    url: string;
+    filename?: string;
 }
 
-export type Option = {
-    v: string | number | null,
-    t: string
+export interface Option {
+    v: string | number | null;
+    t: string;
 }
 
-export type HierarchyNode = {
-    name: string,
-    path: string,
-    children: HierarchyNode[]
+export interface HierarchyNode {
+    name: string;
+    path: string;
+    children: HierarchyNode[];
 }
 
-export type SceneCamera = {
-    name: string,
-    path: string
+export interface SceneCamera {
+    name: string;
+    path: string;
 }
 
-export type ObserverData = {
+export interface ObserverData {
     ui: {
-        fullscreen: boolean,
-        active?: string,
-        spinner: boolean,
-        error?: string,
-        warnings?: string[],
-    },
+        fullscreen: boolean;
+        active?: string;
+        spinner: boolean;
+        error?: string;
+        warnings?: string[];
+    };
     camera: {
-        fov: number,
-        tonemapping: string,
-        pixelScale: number
-        multisampleSupported: boolean,
-        multisample: boolean,
-        hq: boolean,
-        mode: 'orbit' | 'fly',
-        gsaa: boolean,
-        gstwod: boolean
-    },
+        fov: number;
+        tonemapping: string;
+        pixelScale: number;
+        multisampleSupported: boolean;
+        multisample: boolean;
+        hq: boolean;
+        mode: 'orbit' | 'fly';
+        gsaa: boolean;
+        gstwod: boolean;
+    };
     skybox: {
-        value: string,
-        options: string,
-        exposure: number,
-        rotation: number,
-        background: 'Solid Color' | 'Infinite Sphere' | 'Projective Dome' | 'Projective Box',
+        value: string;
+        options: string;
+        exposure: number;
+        rotation: number;
+        background: 'Solid Color' | 'Infinite Sphere' | 'Projective Dome' | 'Projective Box';
         backgroundColor: {
-            r: number,
-            g: number,
-            b: number
-        },
-        blur: number,
+            r: number;
+            g: number;
+            b: number;
+        };
+        blur: number;
         domeProjection: {
-            domeRadius: number,
-            tripodOffset: number
-        }
-    },
+            domeRadius: number;
+            tripodOffset: number;
+        };
+    };
     light: {
-        enabled: boolean,
+        enabled: boolean;
         color: {
-            r: number,
-            g: number,
-            b: number
-        },
-        intensity: number,
-        follow: boolean,
-        shadow: boolean
-    },
+            r: number;
+            g: number;
+            b: number;
+        };
+        intensity: number;
+        follow: boolean;
+        shadow: boolean;
+    };
     shadowCatcher: {
-        enabled: boolean,
-        intensity: number
-    },
+        enabled: boolean;
+        intensity: number;
+    };
     debug: {
-        renderMode: 'default' | 'albedo' | 'opacity' | 'worldNormal' | 'specularity' | 'gloss' | 'metalness' | 'ao' | 'emission' | 'lighting' | 'uv0',
-        stats: boolean,
-        wireframe: boolean,
+        renderMode:
+            | 'default'
+            | 'albedo'
+            | 'opacity'
+            | 'worldNormal'
+            | 'specularity'
+            | 'gloss'
+            | 'metalness'
+            | 'ao'
+            | 'emission'
+            | 'lighting'
+            | 'uv0';
+        stats: boolean;
+        wireframe: boolean;
         wireframeColor: {
-            r: number,
-            g: number,
-            b: number
-        },
-        bounds: boolean,
-        skeleton: boolean,
-        axes: boolean,
-        grid: boolean,
-        normals: number
-    },
+            r: number;
+            g: number;
+            b: number;
+        };
+        bounds: boolean;
+        skeleton: boolean;
+        axes: boolean;
+        grid: boolean;
+        normals: number;
+    };
     animation: {
-        playing: boolean,
-        speed: number,
-        transition: number,
-        loops: number,
-        list: string,
-        progress: number,
-        selectedTrack: string
-    },
+        playing: boolean;
+        speed: number;
+        transition: number;
+        loops: number;
+        list: string;
+        progress: number;
+        selectedTrack: string;
+    };
     scene: {
-        urls: string[],
-        filenames: string[],
-        nodes: string,
+        urls: string[];
+        filenames: string[];
+        nodes: string;
         selectedNode: {
-            path: string,
-            name?: string,
+            path: string;
+            name?: string;
             position: {
-                0: number,
-                1: number,
-                2: number
-            },
+                0: number;
+                1: number;
+                2: number;
+            };
             rotation: {
-                0: number,
-                1: number,
-                2: number,
-                3: number
-            },
+                0: number;
+                1: number;
+                2: number;
+                3: number;
+            };
             scale: {
-                0: number,
-                1: number,
-                2: number
-            }
-        },
-        meshCount?: number,
-        materialCount?: number,
-        textureCount?: number,
-        vertexCount?: number,
-        primitiveCount?: number,
-        textureVRAM?: number,
-        meshVRAM?: number,
-        bounds?: any,
+                0: number;
+                1: number;
+                2: number;
+            };
+        };
+        meshCount?: number;
+        materialCount?: number;
+        textureCount?: number;
+        vertexCount?: number;
+        primitiveCount?: number;
+        textureVRAM?: number;
+        meshVRAM?: number;
+        bounds?: any;
         variant: {
-            selected: number
-        },
+            selected: number;
+        };
         variants: {
-            list: string
-        },
-        loadTime?: number,
-        cameras: string,
-        selectedCamera: string
-    },
-    morphs?: Record<string, {
-        name: string,
-        targets: Record<string, MorphTargetData>
-    }>,
+            list: string;
+        };
+        loadTime?: number;
+        cameras: string;
+        selectedCamera: string;
+    };
+    morphs?: Record<
+        string,
+        {
+            name: string;
+            targets: Record<string, MorphTargetData>;
+        }
+    >;
     runtime: {
-        activeDeviceType: string,
-        viewportWidth: number,
-        viewportHeight: number,
-        xrSupported: boolean,
-        xrActive: boolean
-    },
-    enableWebGPU: boolean,
-    centerScene: boolean,
+        activeDeviceType: string;
+        viewportWidth: number;
+        viewportHeight: number;
+        xrSupported: boolean;
+        xrActive: boolean;
+    };
+    enableWebGPU: boolean;
+    centerScene: boolean;
 }
 
 export type SetProperty = (path: string, value: any) => void;

--- a/src/ui/components/index.tsx
+++ b/src/ui/components/index.tsx
@@ -85,7 +85,7 @@ export const ToggleColor = (props: {
 export const SelectColor = (props: {
     label: string,
     selectType: 'string' | 'number' | 'boolean',
-    selectOptions: Array<Option>,
+    selectOptions: Option[],
     selectValue: any,
     setSelectProperty: (value: any) => void,
     colorValue: any,
@@ -223,7 +223,7 @@ export const Select = (props: {
     value:any,
     setProperty: (value: any) => void,
     type: 'string' | 'number' | 'boolean',
-    options: Array<Option>,
+    options: Option[],
     enabled?: boolean,
     selectKey?: string }) => {
 
@@ -251,7 +251,7 @@ export const NakedSelect = (props: {
     setProperty: any,
     width: number,
     type: 'string' | 'number' | 'boolean',
-    options: Array<Option>,
+    options: Option[],
     enabled?: boolean,
     id?: string,
     class?: string }) => {

--- a/src/ui/components/index.tsx
+++ b/src/ui/components/index.tsx
@@ -21,7 +21,12 @@ export const Detail = (props: { label: string; value: string | number }) => {
     );
 };
 
-export const Vector = (props: { label: string; value: any; dimensions: 2 | 3 | 4; enabled?: boolean }) => {
+export const Vector = (props: {
+    label: string;
+    value: number[] | string | Record<number, number>;
+    dimensions: 2 | 3 | 4;
+    enabled?: boolean;
+}) => {
     return (
         <Container class="panel-option" enabled={props.enabled ?? true}>
             <Label class="panel-label" text={props.label} />
@@ -53,8 +58,8 @@ export const ToggleColor = (props: {
     label: string;
     booleanValue: boolean;
     setBooleanProperty: (value: boolean) => void;
-    colorValue: any;
-    setColorProperty: (value: any) => void;
+    colorValue: number[];
+    setColorProperty: (value: number[]) => void;
 }) => {
     return (
         <Container class="panel-option">
@@ -68,7 +73,7 @@ export const ToggleColor = (props: {
                 <ColorPicker
                     class="panel-value-toggle-color"
                     value={props.colorValue}
-                    onChange={(value: any) => props.setColorProperty(value)}
+                    onChange={(value: number[]) => props.setColorProperty(value)}
                 />
             </Container>
         </Container>
@@ -79,10 +84,10 @@ export const SelectColor = (props: {
     label: string;
     selectType: 'string' | 'number' | 'boolean';
     selectOptions: Option[];
-    selectValue: any;
-    setSelectProperty: (value: any) => void;
-    colorValue: any;
-    setColorProperty: (value: any) => void;
+    selectValue: Option['v'];
+    setSelectProperty: (value: Option['v']) => void;
+    colorValue: number[];
+    setColorProperty: (value: number[]) => void;
 }) => {
     return (
         <Container class="panel-option">
@@ -93,12 +98,12 @@ export const SelectColor = (props: {
                     type={props.selectType}
                     options={props.selectOptions}
                     value={props.selectValue}
-                    onChange={(value: any) => props.setSelectProperty(value)}
+                    onChange={(value: Option['v']) => props.setSelectProperty(value)}
                 />
                 <ColorPicker
                     class="panel-value-color"
                     value={props.colorValue}
-                    onChange={(value: any) => props.setColorProperty(value)}
+                    onChange={(value: number[]) => props.setColorProperty(value)}
                 />
             </Container>
         </Container>
@@ -126,7 +131,7 @@ export const Slider = (props: {
                 sliderMax={props.max}
                 precision={props.precision}
                 step={props.step ?? 0.01}
-                onChange={(value: any) => {
+                onChange={(value: number) => {
                     props.setProperty(value);
                 }}
                 value={props.value}
@@ -150,7 +155,7 @@ export const Numeric = (props: {
                 class="panel-value"
                 min={props.min}
                 max={props.max}
-                onChange={(value: any) => {
+                onChange={(value: number) => {
                     props.setProperty(value);
                 }}
                 value={props.value}
@@ -161,15 +166,19 @@ export const Numeric = (props: {
 
 export const ColorPickerControl = (props: {
     label: string;
-    value: any;
-    setProperty: (value: any) => void;
+    value: number[];
+    setProperty: (value: number[]) => void;
     enabled?: boolean;
     hidden?: boolean;
 }) => {
     return (
         <Container class="panel-option" hidden={props.hidden} enabled={props.enabled ?? true}>
             <Label class="panel-label" text={props.label} />
-            <ColorPicker class="panel-value" value={props.value} onChange={(value: any) => props.setProperty(value)} />
+            <ColorPicker
+                class="panel-value"
+                value={props.value}
+                onChange={(value: number[]) => props.setProperty(value)}
+            />
         </Container>
     );
 };
@@ -207,7 +216,7 @@ export const MorphSlider = (props: {
                 sliderMax={props.max}
                 precision={props.precision}
                 step={0.01}
-                onChange={(value: any) => {
+                onChange={(value: number) => {
                     props.setProperty(value);
                 }}
                 value={props.value}
@@ -218,8 +227,8 @@ export const MorphSlider = (props: {
 
 export const Select = (props: {
     label: string;
-    value: any;
-    setProperty: (value: any) => void;
+    value: Option['v'];
+    setProperty: (value: Option['v']) => void;
     type: 'string' | 'number' | 'boolean';
     options: Option[];
     enabled?: boolean;
@@ -234,7 +243,7 @@ export const Select = (props: {
                 type={props.type}
                 options={props.options}
                 value={props.value}
-                onChange={(value: any) => {
+                onChange={(value: Option['v']) => {
                     props.setProperty(value);
                 }}
             />
@@ -245,8 +254,8 @@ export const Select = (props: {
 // naked versions
 
 export const NakedSelect = (props: {
-    value: any;
-    setProperty: any;
+    value: Option['v'];
+    setProperty: (value: Option['v']) => void;
     width: number;
     type: 'string' | 'number' | 'boolean';
     options: Option[];
@@ -263,7 +272,7 @@ export const NakedSelect = (props: {
             options={props.options}
             enabled={props.enabled ?? true}
             value={props.value}
-            onChange={(value: any) => {
+            onChange={(value: Option['v']) => {
                 props.setProperty(value);
             }}
         />
@@ -271,8 +280,8 @@ export const NakedSelect = (props: {
 };
 
 export const NakedSlider = (props: {
-    value: any;
-    setProperty: any;
+    value: number;
+    setProperty: (value: number) => void;
     width: number;
     precision: number;
     min: number;
@@ -294,7 +303,7 @@ export const NakedSlider = (props: {
             step={0.01}
             enabled={props.enabled ?? true}
             value={props.value}
-            onChange={(value: any) => {
+            onChange={(value: number) => {
                 props.setProperty(value);
             }}
         />

--- a/src/ui/components/index.tsx
+++ b/src/ui/components/index.tsx
@@ -10,291 +10,293 @@ import {
 } from '@playcanvas/pcui/react';
 import React from 'react';
 
-import { Option } from '../../types';
+import type { Option } from '../../types';
 
-export const Detail = (props: { label: string, value:string|number}) => {
-    return <Container class='panel-option'>
-        <Label
-            class='panel-label'
-            text={props.label} />
-        <Label
-            class='panel-value'
-            text={String(props.value)}/>
-    </Container>;
+export const Detail = (props: { label: string; value: string | number }) => {
+    return (
+        <Container class="panel-option">
+            <Label class="panel-label" text={props.label} />
+            <Label class="panel-value" text={String(props.value)} />
+        </Container>
+    );
 };
 
-export const Vector = (props: {
-    label: string,
-    value:any,
-    dimensions: 2 | 3 | 4,
-    enabled?: boolean}) => {
-
-    return <Container class='panel-option' enabled={props.enabled ?? true}>
-        <Label
-            class='panel-label'
-            text={props.label} />
-        <VectorInput class='panel-value'
-            dimensions={props.dimensions}
-            value={props.value}
-            precision={7} />
-    </Container>;
+export const Vector = (props: { label: string; value: any; dimensions: 2 | 3 | 4; enabled?: boolean }) => {
+    return (
+        <Container class="panel-option" enabled={props.enabled ?? true}>
+            <Label class="panel-label" text={props.label} />
+            <VectorInput class="panel-value" dimensions={props.dimensions} value={props.value} precision={7} />
+        </Container>
+    );
 };
 
 export const Toggle = (props: {
-    label: string,
-    enabled?: boolean,
-    setProperty: (value: boolean) => void,
-    value: boolean }) => {
-
-    return <Container class='panel-option' enabled={props.enabled ?? true}>
-        <Label
-            class='panel-label'
-            text={props.label} />
-        <BooleanInput
-            class='panel-value-boolean'
-            type='toggle'
-            value={props.value}
-            onChange={(value: boolean) => props.setProperty(value)} />
-    </Container>;
+    label: string;
+    enabled?: boolean;
+    setProperty: (value: boolean) => void;
+    value: boolean;
+}) => {
+    return (
+        <Container class="panel-option" enabled={props.enabled ?? true}>
+            <Label class="panel-label" text={props.label} />
+            <BooleanInput
+                class="panel-value-boolean"
+                type="toggle"
+                value={props.value}
+                onChange={(value: boolean) => props.setProperty(value)}
+            />
+        </Container>
+    );
 };
 
 export const ToggleColor = (props: {
-        label: string,
-        booleanValue: boolean,
-        setBooleanProperty: (value: boolean) => void,
-        colorValue: any,
-        setColorProperty: (value: any) => void
-    }) => {
-    return <Container class='panel-option'>
-        <Label
-            class='panel-label'
-            text={props.label} />
-        <Container class='panel-value'>
-            <BooleanInput
-                type='toggle'
-                value={props.booleanValue}
-                onChange={(value: boolean) => props.setBooleanProperty(value)} />
-            <ColorPicker
-                class='panel-value-toggle-color'
-                value={props.colorValue}
-                onChange={(value: any) => props.setColorProperty(value)} />
+    label: string;
+    booleanValue: boolean;
+    setBooleanProperty: (value: boolean) => void;
+    colorValue: any;
+    setColorProperty: (value: any) => void;
+}) => {
+    return (
+        <Container class="panel-option">
+            <Label class="panel-label" text={props.label} />
+            <Container class="panel-value">
+                <BooleanInput
+                    type="toggle"
+                    value={props.booleanValue}
+                    onChange={(value: boolean) => props.setBooleanProperty(value)}
+                />
+                <ColorPicker
+                    class="panel-value-toggle-color"
+                    value={props.colorValue}
+                    onChange={(value: any) => props.setColorProperty(value)}
+                />
+            </Container>
         </Container>
-    </Container>;
+    );
 };
 
 export const SelectColor = (props: {
-    label: string,
-    selectType: 'string' | 'number' | 'boolean',
-    selectOptions: Option[],
-    selectValue: any,
-    setSelectProperty: (value: any) => void,
-    colorValue: any,
-    setColorProperty: (value: any) => void }) => {
-
-    return <Container class='panel-option'>
-        <Label
-            class='panel-label'
-            text={props.label} />
-        <Container class='panel-value'>
-            <SelectInput
-                class='panel-value-select'
-                type={props.selectType}
-                options={props.selectOptions}
-                value={props.selectValue}
-                onChange={(value: any) => props.setSelectProperty(value)} />
-            <ColorPicker
-                class='panel-value-color'
-                value={props.colorValue}
-                onChange={(value: any) => props.setColorProperty(value)} />
+    label: string;
+    selectType: 'string' | 'number' | 'boolean';
+    selectOptions: Option[];
+    selectValue: any;
+    setSelectProperty: (value: any) => void;
+    colorValue: any;
+    setColorProperty: (value: any) => void;
+}) => {
+    return (
+        <Container class="panel-option">
+            <Label class="panel-label" text={props.label} />
+            <Container class="panel-value">
+                <SelectInput
+                    class="panel-value-select"
+                    type={props.selectType}
+                    options={props.selectOptions}
+                    value={props.selectValue}
+                    onChange={(value: any) => props.setSelectProperty(value)}
+                />
+                <ColorPicker
+                    class="panel-value-color"
+                    value={props.colorValue}
+                    onChange={(value: any) => props.setColorProperty(value)}
+                />
+            </Container>
         </Container>
-    </Container>;
+    );
 };
 
 export const Slider = (props: {
-    label: string,
-    value: number,
-    setProperty: (value: number) => void,
-    precision: number,
-    min: number,
-    max: number,
-    enabled?: boolean
-    step?: number }) => {
-
-    return <Container class='panel-option' enabled={props.enabled ?? true}>
-        <Label
-            class='panel-label'
-            text={props.label}
-        />
-        <SliderInput
-            class='panel-value'
-            min={props.min}
-            max={props.max}
-            sliderMin={props.min}
-            sliderMax={props.max}
-            precision={props.precision}
-            step={props.step ?? 0.01}
-            onChange={(value: any) => {
-                props.setProperty(value);
-            }}
-            value={props.value}
-        />
-    </Container>;
+    label: string;
+    value: number;
+    setProperty: (value: number) => void;
+    precision: number;
+    min: number;
+    max: number;
+    enabled?: boolean;
+    step?: number;
+}) => {
+    return (
+        <Container class="panel-option" enabled={props.enabled ?? true}>
+            <Label class="panel-label" text={props.label} />
+            <SliderInput
+                class="panel-value"
+                min={props.min}
+                max={props.max}
+                sliderMin={props.min}
+                sliderMax={props.max}
+                precision={props.precision}
+                step={props.step ?? 0.01}
+                onChange={(value: any) => {
+                    props.setProperty(value);
+                }}
+                value={props.value}
+            />
+        </Container>
+    );
 };
 
 export const Numeric = (props: {
-    label: string,
-    value: number,
-    setProperty: (value: number) => void,
-    min: number,
-    max: number,
-    enabled?: boolean }) => {
-
-    return <Container class='panel-option' enabled={props.enabled ?? true}>
-        <Label
-            class='panel-label'
-            text={props.label} />
-        <NumericInput
-            class='panel-value'
-            min={props.min}
-            max={props.max}
-            onChange={(value: any) => {
-                props.setProperty(value);
-            }}
-            value={props.value}
-        />
-    </Container>;
+    label: string;
+    value: number;
+    setProperty: (value: number) => void;
+    min: number;
+    max: number;
+    enabled?: boolean;
+}) => {
+    return (
+        <Container class="panel-option" enabled={props.enabled ?? true}>
+            <Label class="panel-label" text={props.label} />
+            <NumericInput
+                class="panel-value"
+                min={props.min}
+                max={props.max}
+                onChange={(value: any) => {
+                    props.setProperty(value);
+                }}
+                value={props.value}
+            />
+        </Container>
+    );
 };
 
 export const ColorPickerControl = (props: {
-    label: string,
-    value: any,
-    setProperty: (value: any) => void,
-    enabled?: boolean,
-    hidden?: boolean }) => {
-
-    return <Container class='panel-option' hidden={props.hidden} enabled={props.enabled ?? true}>
-        <Label
-            class='panel-label'
-            text={props.label} />
-        <ColorPicker
-            class='panel-value'
-            value={props.value}
-            onChange={(value: any) => props.setProperty(value)} />
-    </Container>;
+    label: string;
+    value: any;
+    setProperty: (value: any) => void;
+    enabled?: boolean;
+    hidden?: boolean;
+}) => {
+    return (
+        <Container class="panel-option" hidden={props.hidden} enabled={props.enabled ?? true}>
+            <Label class="panel-label" text={props.label} />
+            <ColorPicker class="panel-value" value={props.value} onChange={(value: any) => props.setProperty(value)} />
+        </Container>
+    );
 };
 
 export const MorphSlider = (props: {
-    value: number,
-    setProperty: (value: number) => void,
-    name: string,
-    precision: number,
-    min: number,
-    max: number,
-    label?: string,
-    enabled?: boolean }) => {
+    value: number;
+    setProperty: (value: number) => void;
+    name: string;
+    precision: number;
+    min: number;
+    max: number;
+    label?: string;
+    enabled?: boolean;
+}) => {
+    return (
+        <Container class="panel-option" enabled={props.enabled ?? true}>
+            <Label
+                class="morph-label"
+                flexGrow={'1'}
+                flexShrink={'1'}
+                text={
+                    props.label
+                        ? props.label
+                        : props.name.substring(0, 1).toUpperCase() + props.name.substring(1, props.name.length)
+                }
+                flex
+            />
+            <SliderInput
+                class="morph-value"
+                flexGrow={'0'}
+                flexShrink={'0'}
+                min={props.min}
+                max={props.max}
+                sliderMin={props.min}
+                sliderMax={props.max}
+                precision={props.precision}
+                step={0.01}
+                onChange={(value: any) => {
+                    props.setProperty(value);
+                }}
+                value={props.value}
+            />
+        </Container>
+    );
+};
 
-    return <Container class='panel-option' enabled={props.enabled ?? true}>
-        <Label
-            class='morph-label'
-            flexGrow={'1'}
-            flexShrink={'1'}
-            text={props.label ? props.label : props.name.substring(0, 1).toUpperCase() + props.name.substring(1, props.name.length)}
-            flex />
+export const Select = (props: {
+    label: string;
+    value: any;
+    setProperty: (value: any) => void;
+    type: 'string' | 'number' | 'boolean';
+    options: Option[];
+    enabled?: boolean;
+    selectKey?: string;
+}) => {
+    return (
+        <Container class="panel-option" enabled={props.enabled ?? true}>
+            <Label class="panel-label" text={props.label} />
+            <SelectInput
+                key={props.selectKey}
+                class="panel-value"
+                type={props.type}
+                options={props.options}
+                value={props.value}
+                onChange={(value: any) => {
+                    props.setProperty(value);
+                }}
+            />
+        </Container>
+    );
+};
+
+// naked versions
+
+export const NakedSelect = (props: {
+    value: any;
+    setProperty: any;
+    width: number;
+    type: 'string' | 'number' | 'boolean';
+    options: Option[];
+    enabled?: boolean;
+    id?: string;
+    class?: string;
+}) => {
+    return (
+        <SelectInput
+            id={props.id}
+            class={props.class}
+            width={props.width}
+            type={props.type}
+            options={props.options}
+            enabled={props.enabled ?? true}
+            value={props.value}
+            onChange={(value: any) => {
+                props.setProperty(value);
+            }}
+        />
+    );
+};
+
+export const NakedSlider = (props: {
+    value: any;
+    setProperty: any;
+    width: number;
+    precision: number;
+    min: number;
+    max: number;
+    enabled?: boolean;
+    id?: string;
+    class?: string;
+}) => {
+    return (
         <SliderInput
-            class='morph-value'
-            flexGrow={'0'}
-            flexShrink={'0'}
+            id={props.id}
+            class={props.class}
+            width={props.width}
             min={props.min}
             max={props.max}
             sliderMin={props.min}
             sliderMax={props.max}
             precision={props.precision}
             step={0.01}
-            onChange={(value: any) => {
-                props.setProperty(value);
-            }}
-            value={props.value}
-        />
-    </Container>;
-};
-
-export const Select = (props: {
-    label: string,
-    value:any,
-    setProperty: (value: any) => void,
-    type: 'string' | 'number' | 'boolean',
-    options: Option[],
-    enabled?: boolean,
-    selectKey?: string }) => {
-
-    return <Container class='panel-option' enabled={props.enabled ?? true}>
-        <Label
-            class='panel-label'
-            text={props.label} />
-        <SelectInput
-            key={props.selectKey}
-            class='panel-value'
-            type={props.type}
-            options={props.options}
+            enabled={props.enabled ?? true}
             value={props.value}
             onChange={(value: any) => {
                 props.setProperty(value);
             }}
         />
-    </Container>;
-};
-
-// naked versions
-
-export const NakedSelect = (props: {
-    value: any,
-    setProperty: any,
-    width: number,
-    type: 'string' | 'number' | 'boolean',
-    options: Option[],
-    enabled?: boolean,
-    id?: string,
-    class?: string }) => {
-
-    return <SelectInput
-        id={props.id}
-        class={props.class}
-        width={props.width}
-        type={props.type}
-        options={props.options}
-        enabled={props.enabled ?? true}
-        value={props.value}
-        onChange={(value: any) => {
-            props.setProperty(value);
-        }}
-    />;
-};
-
-export const NakedSlider = (props: {
-    value: any,
-    setProperty: any,
-    width: number,
-    precision: number,
-    min: number,
-    max: number,
-    enabled?: boolean,
-    id?: string,
-    class?: string }) => {
-
-    return <SliderInput
-        id={props.id}
-        class={props.class}
-        width={props.width}
-        min={props.min}
-        max={props.max}
-        sliderMin={props.min}
-        sliderMax={props.max}
-        precision={props.precision}
-        step={0.01}
-        enabled={props.enabled ?? true}
-        value={props.value}
-        onChange={(value: any) => {
-            props.setProperty(value);
-        }}
-    />;
+    );
 };

--- a/src/ui/errors.tsx
+++ b/src/ui/errors.tsx
@@ -1,10 +1,10 @@
 import { Button, InfoBox } from '@playcanvas/pcui/react';
 import React from 'react';
 
-import { ObserverData, SetProperty } from '../types';
+import type { ObserverData, SetProperty } from '../types';
 
 // InfoBox that shows an error
-const ErrorBox = (props: { observerData: ObserverData, setProperty: SetProperty }) => {
+const ErrorBox = (props: { observerData: ObserverData; setProperty: SetProperty }) => {
     const error = props.observerData.ui.error;
 
     const handleDismiss = () => {
@@ -15,19 +15,16 @@ const ErrorBox = (props: { observerData: ObserverData, setProperty: SetProperty 
         return null;
     }
 
-    return <div className="pcui-error-container">
-        <InfoBox
-            class="pcui-error"
-            title='Error'
-            text={error}
-            icon='E218'
-        />
-        <Button text="OK" onClick={handleDismiss} />
-    </div>;
+    return (
+        <div className="pcui-error-container">
+            <InfoBox class="pcui-error" title="Error" text={error} icon="E218" />
+            <Button text="OK" onClick={handleDismiss} />
+        </div>
+    );
 };
 
 // InfoBox that shows warnings (e.g., missing textures)
-const WarningsBox = (props: { observerData: ObserverData, setProperty: SetProperty }) => {
+const WarningsBox = (props: { observerData: ObserverData; setProperty: SetProperty }) => {
     const warnings = props.observerData.ui.warnings;
     const hasWarnings = warnings && warnings.length > 0;
 
@@ -52,15 +49,12 @@ const WarningsBox = (props: { observerData: ObserverData, setProperty: SetProper
         return null;
     }
 
-    return <div className="pcui-warning-container">
-        <InfoBox
-            class="pcui-warning"
-            title={title}
-            text={warningText}
-            icon='E218'
-        />
-        <Button text="OK" onClick={handleDismiss} />
-    </div>;
+    return (
+        <div className="pcui-warning-container">
+            <InfoBox class="pcui-warning" title={title} text={warningText} icon="E218" />
+            <Button text="OK" onClick={handleDismiss} />
+        </div>
+    );
 };
 
 export { ErrorBox, WarningsBox };

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -4,13 +4,14 @@ import React from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 
+import { version as appVersion } from '../../package.json';
 import { ObserverData } from '../types';
+
 import { ErrorBox, WarningsBox } from './errors';
 import LeftPanel from './left-panel';
 import LoadControls from './load-controls';
 import PopupPanel from './popup-panel';
 import SelectedNode from './selected-node';
-import { version as appVersion } from '../../package.json';
 
 class App extends React.Component<{ observer: Observer }> {
     state: ObserverData = null;

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -5,7 +5,7 @@ import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 
 import { version as appVersion } from '../../package.json';
-import type { ObserverData } from '../types';
+import type { ObserverData, PropertyValue } from '../types';
 
 import { ErrorBox, WarningsBox } from './errors';
 import LeftPanel from './left-panel';
@@ -16,9 +16,9 @@ import SelectedNode from './selected-node';
 class App extends React.Component<{ observer: Observer }> {
     state: ObserverData = null;
 
-    canvasRef: any;
+    canvasRef: React.RefObject<HTMLCanvasElement | null>;
 
-    constructor(props: any) {
+    constructor(props: { observer: Observer }) {
         super(props);
 
         this.canvasRef = React.createRef();
@@ -31,14 +31,14 @@ class App extends React.Component<{ observer: Observer }> {
     }
 
     _retrieveState = () => {
-        const state: any = {};
-        (this.props.observer as any)._keys.forEach((key: string) => {
+        const state = {} as Record<keyof ObserverData, unknown>;
+        (this.props.observer as unknown as { _keys: (keyof ObserverData)[] })._keys.forEach((key) => {
             state[key] = this.props.observer.get(key);
         });
-        return state;
+        return state as unknown as ObserverData;
     };
 
-    _setStateProperty = (path: string, value: string) => {
+    _setStateProperty = (path: string, value: PropertyValue) => {
         this.props.observer.set(path, value);
     };
 

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,11 +1,11 @@
-import { Observer } from '@playcanvas/observer';
+import type { Observer } from '@playcanvas/observer';
 import { Container, Spinner } from '@playcanvas/pcui/react';
 import React from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 
 import { version as appVersion } from '../../package.json';
-import { ObserverData } from '../types';
+import type { ObserverData } from '../types';
 
 import { ErrorBox, WarningsBox } from './errors';
 import LeftPanel from './left-panel';
@@ -44,35 +44,39 @@ class App extends React.Component<{ observer: Observer }> {
 
     render() {
         const xrActive = this.state?.runtime?.xrActive;
-        return <div id="application-container">
-            <Container id="panel-left" flex resizable='right' resizeMin={220} resizeMax={800} hidden={xrActive}>
-                <div className="header" style={{ display: 'none' }}>
-                    <div id="title">
-                        <img src={'static/playcanvas-logo.png'}/>
-                        <div>{`MODEL VIEWER v${appVersion}`}</div>
+        return (
+            <div id="application-container">
+                <Container id="panel-left" flex resizable="right" resizeMin={220} resizeMax={800} hidden={xrActive}>
+                    <div className="header" style={{ display: 'none' }}>
+                        <div id="title">
+                            {/* eslint-disable-next-line jsx-a11y/alt-text -- preserve markup */}
+                            <img src={'static/playcanvas-logo.png'} />
+                            <div>{`MODEL VIEWER v${appVersion}`}</div>
+                        </div>
                     </div>
+                    <div id="panel-toggle">
+                        {/* eslint-disable-next-line jsx-a11y/alt-text -- preserve markup */}
+                        <img src={'static/playcanvas-logo.png'} />
+                    </div>
+                    <LeftPanel observerData={this.state} setProperty={this._setStateProperty} />
+                </Container>
+                <div id="canvas-wrapper">
+                    <canvas id="application-canvas" ref={this.canvasRef} />
+                    <LoadControls setProperty={this._setStateProperty} />
+                    <SelectedNode sceneData={this.state.scene} />
+                    <PopupPanel observerData={this.state} setProperty={this._setStateProperty} />
+                    <ErrorBox observerData={this.state} setProperty={this._setStateProperty} />
+                    <WarningsBox observerData={this.state} setProperty={this._setStateProperty} />
+                    <Spinner id="spinner" size={30} hidden={true} />
                 </div>
-                <div id="panel-toggle">
-                    <img src={'static/playcanvas-logo.png'}/>
-                </div>
-                <LeftPanel observerData={this.state} setProperty={this._setStateProperty} />
-            </Container>
-            <div id='canvas-wrapper'>
-                <canvas id="application-canvas" ref={this.canvasRef} />
-                <LoadControls setProperty={this._setStateProperty}/>
-                <SelectedNode sceneData={this.state.scene} />
-                <PopupPanel observerData={this.state} setProperty={this._setStateProperty} />
-                <ErrorBox observerData={this.state} setProperty={this._setStateProperty} />
-                <WarningsBox observerData={this.state} setProperty={this._setStateProperty} />
-                <Spinner id="spinner" size={30} hidden={true} />
             </div>
-        </div>;
+        );
     }
 }
 
 export default (observer: Observer) => {
     const root = createRoot(document.getElementById('app'));
-    root.render(<App observer={observer}/>);
+    root.render(<App observer={observer} />);
 
     // Commit the initial mount synchronously
     flushSync(() => {

--- a/src/ui/left-panel/index.tsx
+++ b/src/ui/left-panel/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { addEventListenerOnClickOnly } from '../../helpers';
 import { HierarchyNode, SetProperty, ObserverData } from '../../types';
 import { Detail, Select, Vector } from '../components';
+
 import MorphTargetPanel from './morph-target-panel';
 
 const toggleCollapsed = () => {
@@ -49,7 +50,7 @@ class ScenePanel extends React.Component <{ sceneData: ObserverData['scene'], se
 
     render() {
         const scene = this.props.sceneData;
-        const variantListOptions: Array<{ v:string, t:string }> = JSON.parse(scene.variants.list).map((variant: string) => ({ v: variant, t: variant }));
+        const variantListOptions: { v:string, t:string }[] = JSON.parse(scene.variants.list).map((variant: string) => ({ v: variant, t: variant }));
         return (
             <Panel headerText='SCENE' id='scene-panel' flexShrink={'0'} flexGrow={'0'} collapsible={false} >
                 <Detail label='Filename' value={scene.filenames.join(', ')} />
@@ -82,8 +83,8 @@ class HierarchyPanel extends React.Component <{ sceneData: ObserverData['scene']
 
     render() {
         const scene = this.props.sceneData;
-        const modelHierarchy: Array<HierarchyNode> = JSON.parse(scene.nodes);
-        const mapNodes = (nodes: Array<HierarchyNode>) => {
+        const modelHierarchy: HierarchyNode[] = JSON.parse(scene.nodes);
+        const mapNodes = (nodes: HierarchyNode[]) => {
             return nodes.map((node:HierarchyNode) => <TreeViewItem text={`${node.name}`} key={node.path}
                 onSelect={(TreeViewItem: any) => {
                     this.props.setProperty('scene.selectedNode.path', node.path);

--- a/src/ui/left-panel/index.tsx
+++ b/src/ui/left-panel/index.tsx
@@ -2,7 +2,7 @@ import { Panel, Container, TreeViewItem, TreeView } from '@playcanvas/pcui/react
 import React from 'react';
 
 import { addEventListenerOnClickOnly } from '../../helpers';
-import { HierarchyNode, SetProperty, ObserverData } from '../../types';
+import type { HierarchyNode, SetProperty, ObserverData } from '../../types';
 import { Detail, Select, Vector } from '../components';
 
 import MorphTargetPanel from './morph-target-panel';
@@ -28,11 +28,13 @@ const bytesToSizeString = (bytes: number): string => {
     const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
     if (bytes === 0) return 'n/a';
     const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), sizes.length - 1);
-    return (i === 0) ? `${bytes} ${sizes[i]}` : `${(bytes / (1024 ** i)).toFixed(1)} ${sizes[i]}`;
+    return i === 0 ? `${bytes} ${sizes[i]}` : `${(bytes / 1024 ** i).toFixed(1)} ${sizes[i]}`;
 };
 
-class ScenePanel extends React.Component <{ sceneData: ObserverData['scene'], setProperty: SetProperty }> {
-    shouldComponentUpdate(nextProps: Readonly<{ sceneData: ObserverData['scene']; setProperty: SetProperty; }>): boolean {
+class ScenePanel extends React.Component<{ sceneData: ObserverData['scene']; setProperty: SetProperty }> {
+    shouldComponentUpdate(
+        nextProps: Readonly<{ sceneData: ObserverData['scene']; setProperty: SetProperty }>
+    ): boolean {
         return (
             JSON.stringify(nextProps.sceneData.filenames) !== JSON.stringify(this.props.sceneData.filenames) ||
             nextProps.sceneData.loadTime !== this.props.sceneData.loadTime ||
@@ -50,75 +52,94 @@ class ScenePanel extends React.Component <{ sceneData: ObserverData['scene'], se
 
     render() {
         const scene = this.props.sceneData;
-        const variantListOptions: { v:string, t:string }[] = JSON.parse(scene.variants.list).map((variant: string) => ({ v: variant, t: variant }));
+        const variantListOptions: { v: string; t: string }[] = JSON.parse(scene.variants.list).map(
+            (variant: string) => ({ v: variant, t: variant })
+        );
         return (
-            <Panel headerText='SCENE' id='scene-panel' flexShrink={'0'} flexGrow={'0'} collapsible={false} >
-                <Detail label='Filename' value={scene.filenames.join(', ')} />
-                <Detail label='Meshes' value={scene.meshCount} />
-                <Detail label='Materials' value={scene.materialCount} />
-                <Detail label='Textures' value={scene.textureCount} />
-                <Detail label='Primitives' value={scene.primitiveCount} />
-                <Detail label='Verts' value={scene.vertexCount} />
-                <Detail label='Mesh VRAM' value={bytesToSizeString(scene.meshVRAM)} />
-                <Detail label='Texture VRAM' value={bytesToSizeString(scene.textureVRAM)} />
-                <Detail label='Load time' value={scene.loadTime} />
-                <Vector label='Bounds' dimensions={3} value={scene.bounds} enabled={false}/>
-                <Select label='Variant' type='string' options={variantListOptions} value={scene.variant.selected}
+            <Panel headerText="SCENE" id="scene-panel" flexShrink={'0'} flexGrow={'0'} collapsible={false}>
+                <Detail label="Filename" value={scene.filenames.join(', ')} />
+                <Detail label="Meshes" value={scene.meshCount} />
+                <Detail label="Materials" value={scene.materialCount} />
+                <Detail label="Textures" value={scene.textureCount} />
+                <Detail label="Primitives" value={scene.primitiveCount} />
+                <Detail label="Verts" value={scene.vertexCount} />
+                <Detail label="Mesh VRAM" value={bytesToSizeString(scene.meshVRAM)} />
+                <Detail label="Texture VRAM" value={bytesToSizeString(scene.textureVRAM)} />
+                <Detail label="Load time" value={scene.loadTime} />
+                <Vector label="Bounds" dimensions={3} value={scene.bounds} enabled={false} />
+                <Select
+                    label="Variant"
+                    type="string"
+                    options={variantListOptions}
+                    value={scene.variant.selected}
                     setProperty={(value: string) => {
                         this.props.setProperty('scene.variant.selected', value);
                     }}
-                    enabled={ variantListOptions.length > 0 }
+                    enabled={variantListOptions.length > 0}
                 />
             </Panel>
         );
     }
 }
 
-class HierarchyPanel extends React.Component <{ sceneData: ObserverData['scene'], setProperty: SetProperty }> {
-    shouldComponentUpdate(nextProps: Readonly<{ sceneData: ObserverData['scene']; setProperty: SetProperty; }>): boolean {
-        return (
-            nextProps.sceneData.nodes !== this.props.sceneData.nodes
-        );
+class HierarchyPanel extends React.Component<{ sceneData: ObserverData['scene']; setProperty: SetProperty }> {
+    shouldComponentUpdate(
+        nextProps: Readonly<{ sceneData: ObserverData['scene']; setProperty: SetProperty }>
+    ): boolean {
+        return nextProps.sceneData.nodes !== this.props.sceneData.nodes;
     }
 
     render() {
         const scene = this.props.sceneData;
         const modelHierarchy: HierarchyNode[] = JSON.parse(scene.nodes);
         const mapNodes = (nodes: HierarchyNode[]) => {
-            return nodes.map((node:HierarchyNode) => <TreeViewItem text={`${node.name}`} key={node.path}
-                onSelect={(TreeViewItem: any) => {
-                    this.props.setProperty('scene.selectedNode.path', node.path);
-                    const removeEventListener = addEventListenerOnClickOnly(document.body, () => {
-                        TreeViewItem.selected = false;
-                        removeEventListener();
-                    }, 4);
-                }}
-                onDeselect={() => this.props.setProperty('scene.selectedNode.path', '')}
-            >
-                { mapNodes(node.children) }
-            </TreeViewItem>);
+            return nodes.map((node: HierarchyNode) => (
+                <TreeViewItem
+                    text={`${node.name}`}
+                    key={node.path}
+                    onSelect={(TreeViewItem: any) => {
+                        this.props.setProperty('scene.selectedNode.path', node.path);
+                        const removeEventListener = addEventListenerOnClickOnly(
+                            document.body,
+                            () => {
+                                TreeViewItem.selected = false;
+                                removeEventListener();
+                            },
+                            4
+                        );
+                    }}
+                    onDeselect={() => this.props.setProperty('scene.selectedNode.path', '')}
+                >
+                    {mapNodes(node.children)}
+                </TreeViewItem>
+            ));
         };
         return (
-            <Panel headerText='HIERARCHY' class='scene-hierarchy-panel' enabled={modelHierarchy.length > 0} collapsible={false}>
-                { modelHierarchy.length > 0 &&
+            <Panel
+                headerText="HIERARCHY"
+                class="scene-hierarchy-panel"
+                enabled={modelHierarchy.length > 0}
+                collapsible={false}
+            >
+                {modelHierarchy.length > 0 && (
                     <TreeView allowReordering={false} allowDrag={false}>
-                        { mapNodes(modelHierarchy) }
+                        {mapNodes(modelHierarchy)}
                     </TreeView>
-                }
+                )}
             </Panel>
         );
     }
 }
 
-class LeftPanel extends React.Component <{ observerData: ObserverData, setProperty: SetProperty }> {
+class LeftPanel extends React.Component<{ observerData: ObserverData; setProperty: SetProperty }> {
     isMobile: boolean;
 
     constructor(props: any) {
         super(props);
-        this.isMobile = (/Android|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
+        this.isMobile = /Android|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
     }
 
-    shouldComponentUpdate(nextProps: Readonly<{ observerData: ObserverData; setProperty: SetProperty; }>): boolean {
+    shouldComponentUpdate(nextProps: Readonly<{ observerData: ObserverData; setProperty: SetProperty }>): boolean {
         return JSON.stringify(nextProps.observerData.scene) !== JSON.stringify(this.props.observerData.scene);
     }
 
@@ -135,11 +156,13 @@ class LeftPanel extends React.Component <{ observerData: ObserverData, setProper
         setTimeout(() => toggleCollapsed());
     }
 
-    componentDidUpdate(prevProps: Readonly<{ observerData: ObserverData; setProperty: SetProperty; }>): void {
-        if (!this.isMobile &&
+    componentDidUpdate(prevProps: Readonly<{ observerData: ObserverData; setProperty: SetProperty }>): void {
+        if (
+            !this.isMobile &&
             !this.props.observerData.ui.fullscreen &&
-             this.props.observerData.scene.nodes !== '[]' &&
-             prevProps.observerData.scene.nodes === '[]') {
+            this.props.observerData.scene.nodes !== '[]' &&
+            prevProps.observerData.scene.nodes === '[]'
+        ) {
             openPanel();
         }
     }
@@ -148,11 +171,15 @@ class LeftPanel extends React.Component <{ observerData: ObserverData, setProper
         const scene = this.props.observerData.scene;
         const morphs = this.props.observerData.morphs;
         return (
-            <Container id='scene-container' flex>
+            <Container id="scene-container" flex>
                 <ScenePanel sceneData={scene} setProperty={this.props.setProperty} />
-                <div id='scene-scrolly-bits'>
+                <div id="scene-scrolly-bits">
                     <HierarchyPanel sceneData={scene} setProperty={this.props.setProperty} />
-                    <MorphTargetPanel progress={this.props.observerData.animation.progress} morphs={morphs} setProperty={this.props.setProperty} />
+                    <MorphTargetPanel
+                        progress={this.props.observerData.animation.progress}
+                        morphs={morphs}
+                        setProperty={this.props.setProperty}
+                    />
                 </div>
             </Container>
         );

--- a/src/ui/left-panel/index.tsx
+++ b/src/ui/left-panel/index.tsx
@@ -14,7 +14,7 @@ const toggleCollapsed = () => {
     }
 };
 
-let leftPanel: any;
+let leftPanel: HTMLElement | undefined;
 const openPanel = () => {
     if (!leftPanel) {
         leftPanel = document.getElementById('panel-left');
@@ -97,12 +97,12 @@ class HierarchyPanel extends React.Component<{ sceneData: ObserverData['scene'];
                 <TreeViewItem
                     text={`${node.name}`}
                     key={node.path}
-                    onSelect={(TreeViewItem: any) => {
+                    onSelect={(TreeViewItem) => {
                         this.props.setProperty('scene.selectedNode.path', node.path);
                         const removeEventListener = addEventListenerOnClickOnly(
                             document.body,
                             () => {
-                                TreeViewItem.selected = false;
+                                (TreeViewItem as typeof TreeViewItem & { selected: boolean }).selected = false;
                                 removeEventListener();
                             },
                             4
@@ -134,7 +134,7 @@ class HierarchyPanel extends React.Component<{ sceneData: ObserverData['scene'];
 class LeftPanel extends React.Component<{ observerData: ObserverData; setProperty: SetProperty }> {
     isMobile: boolean;
 
-    constructor(props: any) {
+    constructor(props: { observerData: ObserverData; setProperty: SetProperty }) {
         super(props);
         this.isMobile = /Android|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
     }

--- a/src/ui/left-panel/morph-target-panel.tsx
+++ b/src/ui/left-panel/morph-target-panel.tsx
@@ -17,7 +17,7 @@ class MorphTargetPanel extends React.Component<{
     }
 
     render() {
-        const morphs: any = this.props.morphs;
+        const morphs = this.props.morphs;
         return morphs ? (
             <Panel headerText="MORPH TARGETS" class="scene-morph-panel" collapsible={false}>
                 {Object.keys(morphs).map((morphIndex) => {

--- a/src/ui/left-panel/morph-target-panel.tsx
+++ b/src/ui/left-panel/morph-target-panel.tsx
@@ -2,41 +2,58 @@ import { Panel } from '@playcanvas/pcui/react';
 import React from 'react';
 import { InView } from 'react-intersection-observer';
 
-import { MorphTargetData, SetProperty, ObserverData } from '../../types';
+import type { MorphTargetData, SetProperty, ObserverData } from '../../types';
 import { MorphSlider } from '../components';
 
-class MorphTargetPanel extends React.Component <{ morphs: ObserverData['morphs'], progress: number, setProperty: SetProperty }> {
-    shouldComponentUpdate(nextProps: Readonly<{ morphs: ObserverData['morphs']; progress: number; setProperty: SetProperty; }>): boolean {
-        return (
-            JSON.stringify(nextProps.morphs) !== JSON.stringify(this.props.morphs)
-        );
+class MorphTargetPanel extends React.Component<{
+    morphs: ObserverData['morphs'];
+    progress: number;
+    setProperty: SetProperty;
+}> {
+    shouldComponentUpdate(
+        nextProps: Readonly<{ morphs: ObserverData['morphs']; progress: number; setProperty: SetProperty }>
+    ): boolean {
+        return JSON.stringify(nextProps.morphs) !== JSON.stringify(this.props.morphs);
     }
 
     render() {
         const morphs: any = this.props.morphs;
         return morphs ? (
-            <Panel headerText='MORPH TARGETS' class='scene-morph-panel' collapsible={false}>
+            <Panel headerText="MORPH TARGETS" class="scene-morph-panel" collapsible={false}>
                 {Object.keys(morphs).map((morphIndex) => {
                     const morph = morphs[morphIndex];
                     return (
                         <div key={`${morphIndex}.${morph.name}`}>
-                            <Panel headerText={morph.name} collapsible class='morph-target-panel'>
+                            <Panel headerText={morph.name} collapsible class="morph-target-panel">
                                 {Object.keys(morph.targets).map((targetIndex: string) => {
                                     const morphTarget: MorphTargetData = morph.targets[targetIndex];
-                                    return <div key={targetIndex}>
-                                        <InView rootMargin="750px 0px">
-                                            {({ inView, ref }) => (
-                                                <div ref={ref}>{
-                                                    inView ?
-                                                        <MorphSlider name={`${morphTarget.name}`} precision={2} min={0} max={1}
-                                                            value={morphTarget.weight}
-                                                            setProperty={(value: number) => this.props.setProperty(`morphs.${morphIndex}.targets.${targetIndex}.weight`, value)}
-                                                        /> :
-                                                        <div style={{ width: 30, height: 30 }}></div>
-                                                }</div>
-                                            )}
-                                        </InView>
-                                    </div>;
+                                    return (
+                                        <div key={targetIndex}>
+                                            <InView rootMargin="750px 0px">
+                                                {({ inView, ref }) => (
+                                                    <div ref={ref}>
+                                                        {inView ? (
+                                                            <MorphSlider
+                                                                name={`${morphTarget.name}`}
+                                                                precision={2}
+                                                                min={0}
+                                                                max={1}
+                                                                value={morphTarget.weight}
+                                                                setProperty={(value: number) =>
+                                                                    this.props.setProperty(
+                                                                        `morphs.${morphIndex}.targets.${targetIndex}.weight`,
+                                                                        value
+                                                                    )
+                                                                }
+                                                            />
+                                                        ) : (
+                                                            <div style={{ width: 30, height: 30 }}></div>
+                                                        )}
+                                                    </div>
+                                                )}
+                                            </InView>
+                                        </div>
+                                    );
                                 })}
                             </Panel>
                         </div>

--- a/src/ui/load-controls.tsx
+++ b/src/ui/load-controls.tsx
@@ -6,7 +6,7 @@ import { File, SetProperty } from '../types';
 
 const validUrl = (url: string) => {
     try {
-        /* eslint-disable-next-line no-new */
+         
         new URL(url);
         return true;
     } catch {
@@ -28,7 +28,7 @@ const LoadControls = (props: { setProperty: SetProperty }) => {
         const viewer = (window as any).viewer;
         const files = event.target.files;
         if (viewer && files.length) {
-            const loadList: Array<File> = [];
+            const loadList: File[] = [];
             for (let i = 0; i < files.length; ++i) {
                 const file = files[i];
                 loadList.push({

--- a/src/ui/load-controls.tsx
+++ b/src/ui/load-controls.tsx
@@ -15,16 +15,16 @@ const validUrl = (url: string) => {
 
 const LoadControls = (props: { setProperty: SetProperty }) => {
     const [urlInputValid, setUrlInputValid] = useState(false);
-    const inputFile = useRef(null);
+    const inputFile = useRef<HTMLInputElement>(null);
 
     const onLoadButtonClick = () => {
         // `current` points to the mounted file input element
         inputFile.current.click();
     };
 
-    const onFileSelected = (event: React.ChangeEvent<any>) => {
+    const onFileSelected = (event: React.ChangeEvent<HTMLInputElement>) => {
         // `event` points to the selected file
-        const viewer = (window as any).viewer;
+        const viewer = window.viewer;
         const files = event.target.files;
         if (viewer && files.length) {
             const loadList: File[] = [];
@@ -40,7 +40,7 @@ const LoadControls = (props: { setProperty: SetProperty }) => {
     };
 
     const onUrlSelected = () => {
-        const viewer = (window as any).viewer;
+        const viewer = window.viewer;
         // @ts-ignore
         const value = document.getElementById('glb-url-input').ui.value;
         const url = new URL(value);

--- a/src/ui/load-controls.tsx
+++ b/src/ui/load-controls.tsx
@@ -2,11 +2,10 @@ import { Container, Label, Button, TextInput } from '@playcanvas/pcui/react';
 import React, { useRef, useState } from 'react';
 
 import { version as appVersion } from '../../package.json';
-import { File, SetProperty } from '../types';
+import type { File, SetProperty } from '../types';
 
 const validUrl = (url: string) => {
     try {
-         
         new URL(url);
         return true;
     } catch {
@@ -47,37 +46,64 @@ const LoadControls = (props: { setProperty: SetProperty }) => {
         const url = new URL(value);
         const filename = url.pathname.split('/').pop();
         const hasExtension = !!filename.split('.').splice(1).pop();
-        viewer.loadFiles([{
-            url: value,
-            filename: filename + (hasExtension ? '' : '.glb')
-        }]);
+        viewer.loadFiles([
+            {
+                url: value,
+                filename: filename + (hasExtension ? '' : '.glb')
+            }
+        ]);
     };
 
     return (
-        <div id='load-controls'>
+        <div id="load-controls">
             <Container class="load-button-panel" enabled flex>
-                <div className='header'>
-                    <img src={'static/playcanvas-logo.png'}/>
+                <div className="header">
+                    {/* eslint-disable-next-line jsx-a11y/alt-text -- preserve markup */}
+                    <img src={'static/playcanvas-logo.png'} />
                     <div>
                         <Label text={`MODEL VIEWER v${appVersion}`} />
                     </div>
-                    <Button onClick={() => {
-                        window.open('https://github.com/playcanvas/model-viewer', '_blank').focus();
-                    }} icon='E259'/>
+                    <Button
+                        onClick={() => {
+                            window.open('https://github.com/playcanvas/model-viewer', '_blank').focus();
+                        }}
+                        icon="E259"
+                    />
                 </div>
-                <input type='file' id='file' accept='.glb,.gltf,.ply' multiple onChange={onFileSelected} ref={inputFile} style={{ display: 'none' }} />
+                <input
+                    type="file"
+                    id="file"
+                    accept=".glb,.gltf,.ply"
+                    multiple
+                    onChange={onFileSelected}
+                    ref={inputFile}
+                    style={{ display: 'none' }}
+                />
+                {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- preserve drag-drop behavior */}
                 <div id="drag-drop" onClick={onLoadButtonClick}>
-                    <Button id="drag-drop-search-icon" icon='E129' />
-                    <Label class='desktop' text="Drag & drop .glb, .gltf, or .ply files, or click to open files" />
-                    <Label class='mobile' text="Click to open files" />
+                    <Button id="drag-drop-search-icon" icon="E129" />
+                    <Label class="desktop" text="Drag & drop .glb, .gltf, or .ply files, or click to open files" />
+                    <Label class="mobile" text="Click to open files" />
                 </div>
-                <Label id='or-text' text="OR" class="centered-label" />
-                <TextInput class='secondary' id='glb-url-input' placeholder='Enter .glb, .gltf, or .ply URL' keyChange onValidate={(value: string) => {
-                    const isValid = validUrl(value);
-                    setUrlInputValid(isValid);
-                    return isValid;
-                }}/>
-                <Button class='secondary' id='glb-url-button' text='LOAD MODEL FROM URL' onClick={onUrlSelected} enabled={urlInputValid}></Button>
+                <Label id="or-text" text="OR" class="centered-label" />
+                <TextInput
+                    class="secondary"
+                    id="glb-url-input"
+                    placeholder="Enter .glb, .gltf, or .ply URL"
+                    keyChange
+                    onValidate={(value: string) => {
+                        const isValid = validUrl(value);
+                        setUrlInputValid(isValid);
+                        return isValid;
+                    }}
+                />
+                <Button
+                    class="secondary"
+                    id="glb-url-button"
+                    text="LOAD MODEL FROM URL"
+                    onClick={onUrlSelected}
+                    enabled={urlInputValid}
+                ></Button>
             </Container>
         </div>
     );

--- a/src/ui/load-controls.tsx
+++ b/src/ui/load-controls.tsx
@@ -41,8 +41,7 @@ const LoadControls = (props: { setProperty: SetProperty }) => {
 
     const onUrlSelected = () => {
         const viewer = window.viewer;
-        // @ts-ignore
-        const value = document.getElementById('glb-url-input').ui.value;
+        const value = (document.getElementById('glb-url-input') as HTMLElement & { ui: { value: string } }).ui.value;
         const url = new URL(value);
         const filename = url.pathname.split('/').pop();
         const hasExtension = !!filename.split('.').splice(1).pop();

--- a/src/ui/popup-panel/animation-controls.tsx
+++ b/src/ui/popup-panel/animation-controls.tsx
@@ -14,9 +14,9 @@ class AnimationTrackSelect extends React.Component <{ animationData: ObserverDat
     render() {
         const props = this.props;
 
-        const animationsList: Array<string> = JSON.parse(props.animationData.list);
+        const animationsList: string[] = JSON.parse(props.animationData.list);
 
-        const selectTrackOptions: Array<{ v: string, t: string }> = animationsList.map((animation: string) => ({ v: animation, t: animation }));
+        const selectTrackOptions: { v: string, t: string }[] = animationsList.map((animation: string) => ({ v: animation, t: animation }));
 
         return (
             <NakedSelect
@@ -36,7 +36,7 @@ class AnimationSpeedSelect extends React.Component <{ animationData: ObserverDat
     render() {
         const props = this.props;
 
-        const speedOptions: Array<{ v: string, t: string }> = [
+        const speedOptions: { v: string, t: string }[] = [
             { v: '0.25', t: '0.25x' },
             { v: '0.5', t: '0.5x' },
             { v: '1', t: '1x' },
@@ -70,7 +70,7 @@ class AnimationControls extends React.Component <{ animationData: ObserverData['
     render() {
         const props = this.props;
 
-        const animationsList: Array<string> = JSON.parse(props.animationData.list);
+        const animationsList: string[] = JSON.parse(props.animationData.list);
         const enabled: boolean =  animationsList.length > 0;
 
         return enabled ? (

--- a/src/ui/popup-panel/animation-controls.tsx
+++ b/src/ui/popup-panel/animation-controls.tsx
@@ -1,14 +1,21 @@
 import { Button } from '@playcanvas/pcui/react';
 import React from 'react';
 
-import { SetProperty, ObserverData } from '../../types';
+import type { SetProperty, ObserverData } from '../../types';
 import { NakedSelect, NakedSlider } from '../components';
 
-class AnimationTrackSelect extends React.Component <{ animationData: ObserverData['animation'], setProperty: SetProperty }> {
-    shouldComponentUpdate(nextProps: Readonly<{ animationData: ObserverData['animation']; setProperty: SetProperty; }>): boolean {
-        return nextProps.animationData.list !== this.props.animationData.list ||
-        nextProps.animationData.playing !== this.props.animationData.playing ||
-        nextProps.animationData.selectedTrack !== this.props.animationData.selectedTrack;
+class AnimationTrackSelect extends React.Component<{
+    animationData: ObserverData['animation'];
+    setProperty: SetProperty;
+}> {
+    shouldComponentUpdate(
+        nextProps: Readonly<{ animationData: ObserverData['animation']; setProperty: SetProperty }>
+    ): boolean {
+        return (
+            nextProps.animationData.list !== this.props.animationData.list ||
+            nextProps.animationData.playing !== this.props.animationData.playing ||
+            nextProps.animationData.selectedTrack !== this.props.animationData.selectedTrack
+        );
     }
 
     render() {
@@ -16,27 +23,37 @@ class AnimationTrackSelect extends React.Component <{ animationData: ObserverDat
 
         const animationsList: string[] = JSON.parse(props.animationData.list);
 
-        const selectTrackOptions: { v: string, t: string }[] = animationsList.map((animation: string) => ({ v: animation, t: animation }));
+        const selectTrackOptions: { v: string; t: string }[] = animationsList.map((animation: string) => ({
+            v: animation,
+            t: animation
+        }));
 
         return (
             <NakedSelect
-                id='anim-track-select'
-                width={160} type='string'
+                id="anim-track-select"
+                width={160}
+                type="string"
                 options={selectTrackOptions}
                 setProperty={(value: string) => props.setProperty('animation.selectedTrack', value)}
-                value={props.animationData.selectedTrack} />
+                value={props.animationData.selectedTrack}
+            />
         );
     }
 }
-class AnimationSpeedSelect extends React.Component <{ animationData: ObserverData['animation'], setProperty: SetProperty }> {
-    shouldComponentUpdate(nextProps: Readonly<{ animationData: ObserverData['animation']; setProperty: SetProperty; }>): boolean {
+class AnimationSpeedSelect extends React.Component<{
+    animationData: ObserverData['animation'];
+    setProperty: SetProperty;
+}> {
+    shouldComponentUpdate(
+        nextProps: Readonly<{ animationData: ObserverData['animation']; setProperty: SetProperty }>
+    ): boolean {
         return nextProps.animationData.speed !== this.props.animationData.speed;
     }
 
     render() {
         const props = this.props;
 
-        const speedOptions: { v: string, t: string }[] = [
+        const speedOptions: { v: string; t: string }[] = [
             { v: '0.25', t: '0.25x' },
             { v: '0.5', t: '0.5x' },
             { v: '1', t: '1x' },
@@ -46,20 +63,26 @@ class AnimationSpeedSelect extends React.Component <{ animationData: ObserverDat
 
         return (
             <NakedSelect
-                id='anim-speed-select'
-                width={60} type='string'
+                id="anim-speed-select"
+                width={60}
+                type="string"
                 setProperty={(value: string) => props.setProperty('animation.speed', value)}
                 value={props.animationData.speed}
-                options={speedOptions} />
+                options={speedOptions}
+            />
         );
     }
 }
 
-
-class AnimationControls extends React.Component <{ animationData: ObserverData['animation'], setProperty: SetProperty }> {
+class AnimationControls extends React.Component<{
+    animationData: ObserverData['animation'];
+    setProperty: SetProperty;
+}> {
     animationState: ObserverData['animation'];
 
-    shouldComponentUpdate(nextProps: Readonly<{ animationData: ObserverData['animation']; setProperty: SetProperty; }>): boolean {
+    shouldComponentUpdate(
+        nextProps: Readonly<{ animationData: ObserverData['animation']; setProperty: SetProperty }>
+    ): boolean {
         return JSON.stringify(nextProps.animationData) !== JSON.stringify(this.props.animationData);
     }
 
@@ -71,27 +94,40 @@ class AnimationControls extends React.Component <{ animationData: ObserverData['
         const props = this.props;
 
         const animationsList: string[] = JSON.parse(props.animationData.list);
-        const enabled: boolean =  animationsList.length > 0;
+        const enabled: boolean = animationsList.length > 0;
 
         return enabled ? (
-            <div className='animation-controls-panel-parent'>
-                <Button class='anim-control-button' width={30} height={30} icon={ props.animationData.playing ? 'E376' : 'E286' } text='' onClick={() => {
-                    props.setProperty('animation.playing', !this.animationState.playing);
-                }} />
+            <div className="animation-controls-panel-parent">
+                <Button
+                    class="anim-control-button"
+                    width={30}
+                    height={30}
+                    icon={props.animationData.playing ? 'E376' : 'E286'}
+                    text=""
+                    onClick={() => {
+                        props.setProperty('animation.playing', !this.animationState.playing);
+                    }}
+                />
                 <AnimationTrackSelect animationData={this.props.animationData} setProperty={this.props.setProperty} />
                 <NakedSlider
-                    id='anim-scrub-slider'
-                    width={240} precision={2} min={0} max={1}
+                    id="anim-scrub-slider"
+                    width={240}
+                    precision={2}
+                    min={0}
+                    max={1}
                     setProperty={(value: number) => {
                         const animationState = this.animationState;
                         animationState.playing = false;
                         animationState.progress = value;
                         props.setProperty('animation', animationState);
                     }}
-                    value={props.animationData.progress}/>
+                    value={props.animationData.progress}
+                />
                 <AnimationSpeedSelect animationData={this.props.animationData} setProperty={this.props.setProperty} />
             </div>
-        ) : <div></div>;
+        ) : (
+            <div></div>
+        );
     }
 }
 

--- a/src/ui/popup-panel/index.tsx
+++ b/src/ui/popup-panel/index.tsx
@@ -2,10 +2,11 @@ import { Button } from '@playcanvas/pcui/react';
 import { UsdzExporter } from 'playcanvas';
 import React from 'react';
 
-import AnimationControls from './animation-controls';
-import { CameraPanel, SkyboxPanel, LightPanel, SettingsPanel, ViewPanel } from './panels';
 import { addEventListenerOnClickOnly } from '../../helpers';
 import { SetProperty, ObserverData } from '../../types';
+
+import AnimationControls from './animation-controls';
+import { CameraPanel, SkyboxPanel, LightPanel, SettingsPanel, ViewPanel } from './panels';
 
 const PopupPanelControls = (props: { observerData: ObserverData, setProperty: SetProperty }) => {
     return (<>

--- a/src/ui/popup-panel/index.tsx
+++ b/src/ui/popup-panel/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@playcanvas/pcui/react';
 import { UsdzExporter } from 'playcanvas';
+import type { Entity } from 'playcanvas';
 import React from 'react';
 
 import { addEventListenerOnClickOnly } from '../../helpers';
@@ -35,10 +36,10 @@ const PopupPanelControls = (props: { observerData: ObserverData; setProperty: Se
 };
 
 class PopupButtonControls extends React.Component<{ observerData: ObserverData; setProperty: SetProperty }> {
-    popupPanelElement: any;
+    popupPanelElement: HTMLElement | undefined;
 
     render() {
-        let removeDeselectEvents: any;
+        let removeDeselectEvents: (() => void) | null | undefined;
         const handleClick = (value: string) => {
             this.props.setProperty('ui.active', this.props.observerData.ui.active === value ? null : value);
 
@@ -47,8 +48,8 @@ class PopupButtonControls extends React.Component<{ observerData: ObserverData; 
             // add the event listener after the current click is complete
             setTimeout(() => {
                 if (removeDeselectEvents) removeDeselectEvents();
-                const deactivateUi = (e: any) => {
-                    if (this.popupPanelElement.contains(e.target)) {
+                const deactivateUi = (e: MouseEvent) => {
+                    if (this.popupPanelElement.contains(e.target as Node)) {
                         return;
                     }
                     this.props.setProperty('ui.active', null);
@@ -116,13 +117,13 @@ const toggleCollapsed = () => {
 class PopupPanel extends React.Component<{ observerData: ObserverData; setProperty: SetProperty }> {
     link: HTMLAnchorElement;
 
-    usdzExporter: any;
+    usdzExporter: UsdzExporter | undefined;
 
     get hasArSupport() {
         return this.props.observerData.runtime.xrSupported || this.usdzExporter;
     }
 
-    constructor(props: any) {
+    constructor(props: { observerData: ObserverData; setProperty: SetProperty }) {
         super(props);
         this.link = document.getElementById('ar-link') as HTMLAnchorElement;
         if (
@@ -151,11 +152,11 @@ class PopupPanel extends React.Component<{ observerData: ObserverData; setProper
                     height={40}
                     onClick={() => {
                         if (this.usdzExporter) {
-                            const sceneRoot = (window as any).viewer.app.root.findByName('sceneRoot');
+                            const sceneRoot = window.viewer.app.root.findByName('sceneRoot') as Entity;
                             // convert the loaded entity into asdz file
                             this.usdzExporter
                                 .build(sceneRoot)
-                                .then((arrayBuffer: any) => {
+                                .then((arrayBuffer: ArrayBuffer) => {
                                     const blob = new Blob([arrayBuffer], { type: 'application/octet-stream' });
                                     this.link.href = URL.createObjectURL(blob);
                                     this.link.click();

--- a/src/ui/popup-panel/index.tsx
+++ b/src/ui/popup-panel/index.tsx
@@ -3,22 +3,38 @@ import { UsdzExporter } from 'playcanvas';
 import React from 'react';
 
 import { addEventListenerOnClickOnly } from '../../helpers';
-import { SetProperty, ObserverData } from '../../types';
+import type { SetProperty, ObserverData } from '../../types';
 
 import AnimationControls from './animation-controls';
 import { CameraPanel, SkyboxPanel, LightPanel, SettingsPanel, ViewPanel } from './panels';
 
-const PopupPanelControls = (props: { observerData: ObserverData, setProperty: SetProperty }) => {
-    return (<>
-        <CameraPanel setProperty={props.setProperty} observerData={props.observerData} />
-        <SkyboxPanel setProperty={props.setProperty} skyboxData={props.observerData.skybox} uiData={props.observerData.ui} />
-        <LightPanel setProperty={props.setProperty} lightData={props.observerData.light} uiData={props.observerData.ui} shadowCatcherData={props.observerData.shadowCatcher}/>
-        <SettingsPanel setProperty={props.setProperty} observerData={props.observerData} />
-        <ViewPanel setProperty={props.setProperty} sceneData={props.observerData.scene} uiData={props.observerData.ui} runtimeData={props.observerData.runtime}/>
-    </>);
+const PopupPanelControls = (props: { observerData: ObserverData; setProperty: SetProperty }) => {
+    return (
+        <>
+            <CameraPanel setProperty={props.setProperty} observerData={props.observerData} />
+            <SkyboxPanel
+                setProperty={props.setProperty}
+                skyboxData={props.observerData.skybox}
+                uiData={props.observerData.ui}
+            />
+            <LightPanel
+                setProperty={props.setProperty}
+                lightData={props.observerData.light}
+                uiData={props.observerData.ui}
+                shadowCatcherData={props.observerData.shadowCatcher}
+            />
+            <SettingsPanel setProperty={props.setProperty} observerData={props.observerData} />
+            <ViewPanel
+                setProperty={props.setProperty}
+                sceneData={props.observerData.scene}
+                uiData={props.observerData.ui}
+                runtimeData={props.observerData.runtime}
+            />
+        </>
+    );
 };
 
-class PopupButtonControls extends React.Component <{ observerData: ObserverData, setProperty: SetProperty }> {
+class PopupButtonControls extends React.Component<{ observerData: ObserverData; setProperty: SetProperty }> {
     popupPanelElement: any;
 
     render() {
@@ -44,17 +60,50 @@ class PopupButtonControls extends React.Component <{ observerData: ObserverData,
         };
 
         const buildClass = (value: string) => {
-            return (this.props.observerData.ui.active === value) ? ['popup-button', 'selected'] : ['popup-button'];
+            return this.props.observerData.ui.active === value ? ['popup-button', 'selected'] : ['popup-button'];
         };
 
         return (
-            <div id='popup-buttons-parent'>
-                <AnimationControls animationData={this.props.observerData.animation} setProperty={this.props.setProperty} />
-                <Button class={buildClass('camera')} icon='E212' width={40} height={40} onClick={() => handleClick('camera')} />
-                <Button class={buildClass('skybox')} icon='E200' width={40} height={40} onClick={() => handleClick('skybox')} />
-                <Button class={buildClass('light')} icon='E194' width={40} height={40} onClick={() => handleClick('light')} />
-                <Button class={buildClass('settings')} icon='E134' width={40} height={40} onClick={() => handleClick('settings')} />
-                <Button class={buildClass('view')} icon='E301' width={40} height={40} onClick={() => handleClick('view')} />
+            <div id="popup-buttons-parent">
+                <AnimationControls
+                    animationData={this.props.observerData.animation}
+                    setProperty={this.props.setProperty}
+                />
+                <Button
+                    class={buildClass('camera')}
+                    icon="E212"
+                    width={40}
+                    height={40}
+                    onClick={() => handleClick('camera')}
+                />
+                <Button
+                    class={buildClass('skybox')}
+                    icon="E200"
+                    width={40}
+                    height={40}
+                    onClick={() => handleClick('skybox')}
+                />
+                <Button
+                    class={buildClass('light')}
+                    icon="E194"
+                    width={40}
+                    height={40}
+                    onClick={() => handleClick('light')}
+                />
+                <Button
+                    class={buildClass('settings')}
+                    icon="E134"
+                    width={40}
+                    height={40}
+                    onClick={() => handleClick('settings')}
+                />
+                <Button
+                    class={buildClass('view')}
+                    icon="E301"
+                    width={40}
+                    height={40}
+                    onClick={() => handleClick('view')}
+                />
             </div>
         );
     }
@@ -64,7 +113,7 @@ const toggleCollapsed = () => {
     document.getElementById('panel-left').classList.toggle('collapsed');
 };
 
-class PopupPanel extends React.Component <{ observerData: ObserverData, setProperty: SetProperty }> {
+class PopupPanel extends React.Component<{ observerData: ObserverData; setProperty: SetProperty }> {
     link: HTMLAnchorElement;
 
     usdzExporter: any;
@@ -75,8 +124,12 @@ class PopupPanel extends React.Component <{ observerData: ObserverData, setPrope
 
     constructor(props: any) {
         super(props);
-        this.link = (document.getElementById('ar-link') as HTMLAnchorElement);
-        if (this.link.relList.supports('ar') || (Boolean(window.webkit?.messageHandlers) && Boolean(/CriOS\/|EdgiOS\/|FxiOS\/|GSA\/|DuckDuckGo\//.test(navigator.userAgent)))) {
+        this.link = document.getElementById('ar-link') as HTMLAnchorElement;
+        if (
+            this.link.relList.supports('ar') ||
+            (Boolean(window.webkit?.messageHandlers) &&
+                Boolean(/CriOS\/|EdgiOS\/|FxiOS\/|GSA\/|DuckDuckGo\//.test(navigator.userAgent)))
+        ) {
             this.usdzExporter = new UsdzExporter();
         }
     }
@@ -85,55 +138,60 @@ class PopupPanel extends React.Component <{ observerData: ObserverData, setPrope
         if (this.props.observerData.runtime.xrActive) {
             return null;
         }
-        return (<div id='popup' className={this.props.observerData.scene.nodes === '[]' ? 'empty' : null}>
-            <PopupPanelControls observerData={this.props.observerData} setProperty={this.props.setProperty} />
-            <PopupButtonControls observerData={this.props.observerData} setProperty={this.props.setProperty} />
-            <Button
-                class='popup-button'
-                id='launch-ar-button'
-                icon='E189'
-                hidden={!this.hasArSupport || this.props.observerData.scene.nodes === '[]'}
-                width={40}
-                height={40}
-                onClick={() => {
-                    if (this.usdzExporter) {
-                        const sceneRoot = (window as any).viewer.app.root.findByName('sceneRoot');
-                        // convert the loaded entity into asdz file
-                        this.usdzExporter.build(sceneRoot).then((arrayBuffer: any) => {
-                            const blob = new Blob([arrayBuffer], { type: 'application/octet-stream' });
-                            this.link.href = URL.createObjectURL(blob);
-                            this.link.click();
-                        }).catch(console.error);
-                    } else {
-                        if (window.viewer) window.viewer.xrMode.start();
-                    }
-                } }
-            />
-            <div id='floating-top-parent'>
+        return (
+            <div id="popup" className={this.props.observerData.scene.nodes === '[]' ? 'empty' : null}>
+                <PopupPanelControls observerData={this.props.observerData} setProperty={this.props.setProperty} />
+                <PopupButtonControls observerData={this.props.observerData} setProperty={this.props.setProperty} />
                 <Button
-                    class='popup-button'
-                    id='fullscreen-button'
-                    icon='E127'
+                    class="popup-button"
+                    id="launch-ar-button"
+                    icon="E189"
+                    hidden={!this.hasArSupport || this.props.observerData.scene.nodes === '[]'}
                     width={40}
                     height={40}
                     onClick={() => {
-                        toggleCollapsed();
-                    } }
+                        if (this.usdzExporter) {
+                            const sceneRoot = (window as any).viewer.app.root.findByName('sceneRoot');
+                            // convert the loaded entity into asdz file
+                            this.usdzExporter
+                                .build(sceneRoot)
+                                .then((arrayBuffer: any) => {
+                                    const blob = new Blob([arrayBuffer], { type: 'application/octet-stream' });
+                                    this.link.href = URL.createObjectURL(blob);
+                                    this.link.click();
+                                })
+                                .catch(console.error);
+                        } else {
+                            if (window.viewer) window.viewer.xrMode.start();
+                        }
+                    }}
                 />
+                <div id="floating-top-parent">
+                    <Button
+                        class="popup-button"
+                        id="fullscreen-button"
+                        icon="E127"
+                        width={40}
+                        height={40}
+                        onClick={() => {
+                            toggleCollapsed();
+                        }}
+                    />
+                </div>
+                <div id="floating-bottom-parent">
+                    <Button
+                        class={['popup-button', 'camera-mode-button', this.props.observerData.camera.mode]}
+                        id="camera-mode-button"
+                        width={40}
+                        height={40}
+                        onClick={() => {
+                            const mode = this.props.observerData.camera.mode === 'orbit' ? 'fly' : 'orbit';
+                            this.props.setProperty('camera.mode', mode);
+                        }}
+                    />
+                </div>
             </div>
-            <div id='floating-bottom-parent'>
-                <Button
-                    class={['popup-button', 'camera-mode-button', this.props.observerData.camera.mode]}
-                    id='camera-mode-button'
-                    width={40}
-                    height={40}
-                    onClick={() => {
-                        const mode = this.props.observerData.camera.mode === 'orbit' ? 'fly' : 'orbit';
-                        this.props.setProperty('camera.mode', mode);
-                    } }
-                />
-            </div>
-        </div>);
+        );
     }
 }
 

--- a/src/ui/popup-panel/panels.tsx
+++ b/src/ui/popup-panel/panels.tsx
@@ -33,7 +33,7 @@ class CameraPanel extends React.Component <{
 
     render() {
         const props = this.props;
-        const sceneCameras: Array<{ name: string, path: string }> = JSON.parse(props.observerData.scene.cameras);
+        const sceneCameras: { name: string, path: string }[] = JSON.parse(props.observerData.scene.cameras);
         const cameraOptions = [{ v: 'viewer', t: 'Viewer' }].concat(
             sceneCameras.map(c => ({ v: c.path, t: c.name }))
         );
@@ -277,7 +277,7 @@ class SettingsPanel extends React.Component <{
                             const message = value ?
                                 'Enable WebGPU? The page will refresh to apply this change.' :
                                 'Disable WebGPU? The page will refresh to apply this change.';
-                            // eslint-disable-next-line no-alert
+                             
                             if (window.confirm(message)) {
                                 props.setProperty('enableWebGPU', value);
                                 setTimeout(() => window.location.reload(), 100);

--- a/src/ui/popup-panel/panels.tsx
+++ b/src/ui/popup-panel/panels.tsx
@@ -10,7 +10,17 @@ import { Detail, Slider, Toggle, Select, ColorPickerControl, ToggleColor, Numeri
 declare global {
     // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- declaration merging
     interface Navigator {
-        readonly gpu: any;
+        readonly gpu: {
+            requestAdapter: () => Promise<{
+                requestDevice: () => Promise<{
+                    createCommandEncoder: () => {
+                        beginRenderPass: (descriptor: object) => { end: () => void };
+                        finish: () => unknown;
+                    };
+                    queue: { submit: (commands: unknown[]) => void };
+                }>;
+            }>;
+        };
     }
 }
 
@@ -416,7 +426,12 @@ class ViewPanel extends React.Component<{
         return `${location.origin}${location.pathname}?${this.props.sceneData.urls.map((url: string) => `load=${url}`).join('&')}`;
     }
 
-    constructor(props: any) {
+    constructor(props: {
+        sceneData: ObserverData['scene'];
+        uiData: ObserverData['ui'];
+        runtimeData: ObserverData['runtime'];
+        setProperty: SetProperty;
+    }) {
         super(props);
         this.isMobile = /Android|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
     }

--- a/src/ui/popup-panel/panels.tsx
+++ b/src/ui/popup-panel/panels.tsx
@@ -1,5 +1,4 @@
 import { Container, Button, Label, TextInput } from '@playcanvas/pcui/react';
-// @ts-ignore no type defs included
 import QRious from 'qrious';
 import React from 'react';
 

--- a/src/ui/popup-panel/panels.tsx
+++ b/src/ui/popup-panel/panels.tsx
@@ -4,27 +4,31 @@ import QRious from 'qrious';
 import React from 'react';
 
 import { extract } from '../../helpers';
-import { SetProperty, ObserverData } from '../../types';
+import type { SetProperty, ObserverData } from '../../types';
 import { Detail, Slider, Toggle, Select, ColorPickerControl, ToggleColor, Numeric } from '../components';
 
 declare global {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- declaration merging
     interface Navigator {
-      readonly gpu: any;
+        readonly gpu: any;
     }
 }
 
-const rgbToArr = (rgb: { r: number, g: number, b: number }) => [rgb.r, rgb.g, rgb.b, 1];
+const rgbToArr = (rgb: { r: number; g: number; b: number }) => [rgb.r, rgb.g, rgb.b, 1];
 const arrToRgb = (arr: number[]) => {
     return { r: arr[0], g: arr[1], b: arr[2] };
 };
 
-class CameraPanel extends React.Component <{
-    observerData: ObserverData,
-    setProperty: SetProperty }> {
-    shouldComponentUpdate(nextProps: Readonly<{
-        observerData: ObserverData;
-        setProperty: SetProperty; }>): boolean {
-
+class CameraPanel extends React.Component<{
+    observerData: ObserverData;
+    setProperty: SetProperty;
+}> {
+    shouldComponentUpdate(
+        nextProps: Readonly<{
+            observerData: ObserverData;
+            setProperty: SetProperty;
+        }>
+    ): boolean {
         const keys = ['ui', 'camera', 'debug', 'animation.playing', 'scene.cameras', 'scene.selectedCamera', 'runtime'];
         const a = extract(nextProps.observerData, keys);
         const b = extract(this.props.observerData, keys);
@@ -33,56 +37,68 @@ class CameraPanel extends React.Component <{
 
     render() {
         const props = this.props;
-        const sceneCameras: { name: string, path: string }[] = JSON.parse(props.observerData.scene.cameras);
+        const sceneCameras: { name: string; path: string }[] = JSON.parse(props.observerData.scene.cameras);
         const cameraOptions = [{ v: 'viewer', t: 'Viewer' }].concat(
-            sceneCameras.map(c => ({ v: c.path, t: c.name }))
+            sceneCameras.map((c) => ({ v: c.path, t: c.name }))
         );
         const selectedCamera = props.observerData.scene.selectedCamera || 'viewer';
         const isViewerCamera = selectedCamera === 'viewer';
 
         return (
-            <div className='popup-panel-parent'>
-                <Container class='popup-panel' flex hidden={props.observerData.ui.active !== 'camera'}>
-                    <Label text='Camera' class='popup-panel-heading' />
+            <div className="popup-panel-parent">
+                <Container class="popup-panel" flex hidden={props.observerData.ui.active !== 'camera'}>
+                    <Label text="Camera" class="popup-panel-heading" />
                     <Select
                         selectKey={props.observerData.scene.cameras}
-                        label='Active Camera'
-                        type='string'
+                        label="Active Camera"
+                        type="string"
                         options={cameraOptions}
                         value={selectedCamera}
-                        setProperty={(value: string) => props.setProperty('scene.selectedCamera', value === 'viewer' ? '' : value)}
-                        enabled={sceneCameras.length > 0} />
+                        setProperty={(value: string) =>
+                            props.setProperty('scene.selectedCamera', value === 'viewer' ? '' : value)
+                        }
+                        enabled={sceneCameras.length > 0}
+                    />
                     <Slider
-                        label='Fov'
+                        label="Fov"
                         precision={0}
                         min={35}
                         max={150}
                         value={props.observerData.camera.fov}
                         setProperty={(value: number) => props.setProperty('camera.fov', value)}
-                        enabled={isViewerCamera} />
+                        enabled={isViewerCamera}
+                    />
                     <Select
-                        label='Tonemap'
-                        type='string'
-                        options={['None', 'Linear', 'Neutral', 'Filmic', 'Hejl', 'ACES', 'ACES2'].map(v => ({ v, t: v }))}
+                        label="Tonemap"
+                        type="string"
+                        options={['None', 'Linear', 'Neutral', 'Filmic', 'Hejl', 'ACES', 'ACES2'].map((v) => ({
+                            v,
+                            t: v
+                        }))}
                         value={props.observerData.camera.tonemapping}
-                        setProperty={(value: number) => props.setProperty('camera.tonemapping', value)} />
+                        setProperty={(value: number) => props.setProperty('camera.tonemapping', value)}
+                    />
                     <Select
-                        label='Pixel Scale'
+                        label="Pixel Scale"
                         value={props.observerData.camera.pixelScale}
-                        type='number'
-                        options={[1, 2, 4, 8, 16].map(v => ({ v: v, t: Number(v).toString() }))}
-                        setProperty={(value: number) => props.setProperty('camera.pixelScale', value)} />
-                    <Detail label='Viewport' value={`${props.observerData.runtime.viewportWidth} x ${props.observerData.runtime.viewportHeight}`} />
+                        type="number"
+                        options={[1, 2, 4, 8, 16].map((v) => ({ v: v, t: Number(v).toString() }))}
+                        setProperty={(value: number) => props.setProperty('camera.pixelScale', value)}
+                    />
+                    <Detail
+                        label="Viewport"
+                        value={`${props.observerData.runtime.viewportWidth} x ${props.observerData.runtime.viewportHeight}`}
+                    />
                     <Toggle
-                        label='Multisample'
+                        label="Multisample"
                         value={props.observerData.camera.multisample}
                         enabled={props.observerData.camera.multisampleSupported}
                         setProperty={(value: boolean) => props.setProperty('camera.multisample', value)}
                     />
                     <Toggle
-                        label='High Quality'
+                        label="High Quality"
                         value={props.observerData.camera.hq}
-                        enabled={!props.observerData.animation.playing && !props.observerData.debug.stats }
+                        enabled={!props.observerData.animation.playing && !props.observerData.debug.stats}
                         setProperty={(value: boolean) => props.setProperty('camera.hq', value)}
                     />
                 </Container>
@@ -91,62 +107,75 @@ class CameraPanel extends React.Component <{
     }
 }
 
-class SkyboxPanel extends React.Component <{
-    skyboxData: ObserverData['skybox'],
-    uiData: ObserverData['ui'],
-    setProperty: SetProperty }> {
-    shouldComponentUpdate(nextProps: Readonly<{
-        skyboxData: ObserverData['skybox'];
-        uiData: ObserverData['ui'];
-        setProperty: SetProperty; }>): boolean {
-
-        return JSON.stringify(nextProps.skyboxData) !== JSON.stringify(this.props.skyboxData) ||
-                JSON.stringify(nextProps.uiData) !== JSON.stringify(this.props.uiData);
+class SkyboxPanel extends React.Component<{
+    skyboxData: ObserverData['skybox'];
+    uiData: ObserverData['ui'];
+    setProperty: SetProperty;
+}> {
+    shouldComponentUpdate(
+        nextProps: Readonly<{
+            skyboxData: ObserverData['skybox'];
+            uiData: ObserverData['ui'];
+            setProperty: SetProperty;
+        }>
+    ): boolean {
+        return (
+            JSON.stringify(nextProps.skyboxData) !== JSON.stringify(this.props.skyboxData) ||
+            JSON.stringify(nextProps.uiData) !== JSON.stringify(this.props.uiData)
+        );
     }
 
     render() {
         const props = this.props;
 
         return (
-            <div className='popup-panel-parent'>
-                <Container class='popup-panel' flex hidden={props.uiData.active !== 'skybox'}>
-                    <Label text='Sky' class='popup-panel-heading' />
+            <div className="popup-panel-parent">
+                <Container class="popup-panel" flex hidden={props.uiData.active !== 'skybox'}>
+                    <Label text="Sky" class="popup-panel-heading" />
                     <Select
-                        label='Environment'
-                        type='string'
+                        label="Environment"
+                        type="string"
                         options={JSON.parse(props.skyboxData.options)}
                         value={props.skyboxData.value}
-                        setProperty={(value: string) => props.setProperty('skybox.value', value)} />
+                        setProperty={(value: string) => props.setProperty('skybox.value', value)}
+                    />
                     <Slider
-                        label='Exposure'
+                        label="Exposure"
                         value={props.skyboxData.exposure}
                         setProperty={(value: number) => props.setProperty('skybox.exposure', value)}
                         precision={2}
                         min={-6}
                         max={6}
-                        enabled={props.skyboxData.value !== 'None'} />
+                        enabled={props.skyboxData.value !== 'None'}
+                    />
                     <Slider
-                        label='Rotation'
+                        label="Rotation"
                         precision={0}
                         min={-180}
                         max={180}
                         value={props.skyboxData.rotation}
                         setProperty={(value: number) => props.setProperty('skybox.rotation', value)}
-                        enabled={props.skyboxData.value !== 'None'} />
+                        enabled={props.skyboxData.value !== 'None'}
+                    />
                     <Select
-                        label='Background'
-                        type='string'
-                        options={['Solid Color', 'Infinite Sphere', 'Projective Dome', 'Projective Box'].map(v => ({ v, t: v }))}
+                        label="Background"
+                        type="string"
+                        options={['Solid Color', 'Infinite Sphere', 'Projective Dome', 'Projective Box'].map((v) => ({
+                            v,
+                            t: v
+                        }))}
                         value={props.skyboxData.background}
                         setProperty={(value: string) => props.setProperty('skybox.background', value)}
-                        enabled={props.skyboxData.value !== 'None'} />
+                        enabled={props.skyboxData.value !== 'None'}
+                    />
                     <ColorPickerControl
-                        label='Background Color'
+                        label="Background Color"
                         value={rgbToArr(props.skyboxData.backgroundColor)}
                         setProperty={(value: number[]) => props.setProperty('skybox.backgroundColor', arrToRgb(value))}
-                        enabled={props.skyboxData.value === 'None' || props.skyboxData.background === 'Solid Color'} />
+                        enabled={props.skyboxData.value === 'None' || props.skyboxData.background === 'Solid Color'}
+                    />
                     <Slider
-                        label='Blur'
+                        label="Blur"
                         // type='number'
                         // options={[0, 1, 2, 3, 4, 5].map(v => ({ v: v, t: v === 0 ? 'Disabled' : `Mip ${v}` }))}
                         value={props.skyboxData.blur}
@@ -155,94 +184,126 @@ class SkyboxPanel extends React.Component <{
                         min={0}
                         max={5}
                         precision={0}
-                        step={1}/>
+                        step={1}
+                    />
                     <Numeric
-                        label='Scale'
+                        label="Scale"
                         value={props.skyboxData.domeProjection.domeRadius}
                         setProperty={(value: number) => props.setProperty('skybox.domeProjection.domeRadius', value)}
                         min={0}
                         max={1000}
-                        enabled={props.skyboxData.value !== 'None' && ['Projective Dome', 'Projective Box'].indexOf(props.skyboxData.background) !== -1} />
+                        enabled={
+                            props.skyboxData.value !== 'None' &&
+                            ['Projective Dome', 'Projective Box'].indexOf(props.skyboxData.background) !== -1
+                        }
+                    />
                     <Slider
-                        label='Tripod Offset'
+                        label="Tripod Offset"
                         value={props.skyboxData.domeProjection.tripodOffset}
                         setProperty={(value: number) => props.setProperty('skybox.domeProjection.tripodOffset', value)}
                         min={0}
                         max={1}
                         precision={2}
-                        enabled={props.skyboxData.value !== 'None' && ['Projective Dome', 'Projective Box'].indexOf(props.skyboxData.background) !== -1} />
+                        enabled={
+                            props.skyboxData.value !== 'None' &&
+                            ['Projective Dome', 'Projective Box'].indexOf(props.skyboxData.background) !== -1
+                        }
+                    />
                 </Container>
             </div>
         );
     }
 }
 
-class LightPanel extends React.Component <{
-    lightData: ObserverData['light'],
-    uiData: ObserverData['ui'],
-    shadowCatcherData: ObserverData['shadowCatcher'],
-    setProperty: SetProperty }> {
-    shouldComponentUpdate(nextProps: Readonly<{
-        lightData: ObserverData['light'];
-        uiData: ObserverData['ui'];
-        setProperty: SetProperty; }>): boolean {
-
-        return JSON.stringify(nextProps.lightData) !== JSON.stringify(this.props.lightData) ||
-               JSON.stringify(nextProps.uiData) !== JSON.stringify(this.props.uiData);
+class LightPanel extends React.Component<{
+    lightData: ObserverData['light'];
+    uiData: ObserverData['ui'];
+    shadowCatcherData: ObserverData['shadowCatcher'];
+    setProperty: SetProperty;
+}> {
+    shouldComponentUpdate(
+        nextProps: Readonly<{
+            lightData: ObserverData['light'];
+            uiData: ObserverData['ui'];
+            setProperty: SetProperty;
+        }>
+    ): boolean {
+        return (
+            JSON.stringify(nextProps.lightData) !== JSON.stringify(this.props.lightData) ||
+            JSON.stringify(nextProps.uiData) !== JSON.stringify(this.props.uiData)
+        );
     }
 
     render() {
         const props = this.props;
 
         return (
-            <div className='popup-panel-parent'>
-                <Container class='popup-panel' flex hidden={props.uiData.active !== 'light'}>
-                    <Label text='Light' class='popup-panel-heading' />
+            <div className="popup-panel-parent">
+                <Container class="popup-panel" flex hidden={props.uiData.active !== 'light'}>
+                    <Label text="Light" class="popup-panel-heading" />
                     <Toggle
-                        label='Enabled'
+                        label="Enabled"
                         value={props.lightData.enabled}
-                        setProperty={(value: boolean) => props.setProperty('light.enabled', value)} />
-                    <Toggle label='Follow Camera'
+                        setProperty={(value: boolean) => props.setProperty('light.enabled', value)}
+                    />
+                    <Toggle
+                        label="Follow Camera"
                         value={props.lightData.follow}
-                        setProperty={(value: boolean) => props.setProperty('light.follow', value)} />
+                        setProperty={(value: boolean) => props.setProperty('light.follow', value)}
+                    />
                     <ColorPickerControl
-                        label='Color'
+                        label="Color"
                         value={rgbToArr(props.lightData.color)}
-                        setProperty={(value: number[]) => props.setProperty('light.color', arrToRgb(value))} />
+                        setProperty={(value: number[]) => props.setProperty('light.color', arrToRgb(value))}
+                    />
                     <Slider
-                        label='Intensity'
-                        precision={2} min={0} max={6}
+                        label="Intensity"
+                        precision={2}
+                        min={0}
+                        max={6}
                         value={props.lightData.intensity}
-                        setProperty={(value: number) => props.setProperty('light.intensity', value)} />
+                        setProperty={(value: number) => props.setProperty('light.intensity', value)}
+                    />
                     <Toggle
-                        label='Cast Shadow'
+                        label="Cast Shadow"
                         value={props.lightData.shadow}
-                        setProperty={(value: boolean) => props.setProperty('light.shadow', value)} />
+                        setProperty={(value: boolean) => props.setProperty('light.shadow', value)}
+                    />
                     <Toggle
-                        label='Shadow Catcher'
+                        label="Shadow Catcher"
                         value={props.shadowCatcherData.enabled}
-                        setProperty={(value: boolean) => props.setProperty('shadowCatcher.enabled', value)} />
+                        setProperty={(value: boolean) => props.setProperty('shadowCatcher.enabled', value)}
+                    />
                     <Slider
-                        label='Catcher Intensity'
-                        precision={2} min={0} max={1}
+                        label="Catcher Intensity"
+                        precision={2}
+                        min={0}
+                        max={1}
                         value={props.shadowCatcherData.intensity}
-                        setProperty={(value: number) => props.setProperty('shadowCatcher.intensity', value)} />
+                        setProperty={(value: number) => props.setProperty('shadowCatcher.intensity', value)}
+                    />
                 </Container>
             </div>
         );
     }
 }
 
-class SettingsPanel extends React.Component <{
-    observerData: ObserverData,
-    setProperty: SetProperty }> {
-    shouldComponentUpdate(nextProps: Readonly<{
-        observerData: ObserverData;
-        setProperty: SetProperty; }>): boolean {
-        return JSON.stringify(nextProps.observerData.debug) !== JSON.stringify(this.props.observerData.debug) ||
-               JSON.stringify(nextProps.observerData.ui) !== JSON.stringify(this.props.observerData.ui) ||
-               nextProps.observerData.enableWebGPU !== this.props.observerData.enableWebGPU ||
-               nextProps.observerData.runtime.activeDeviceType !== this.props.observerData.runtime.activeDeviceType;
+class SettingsPanel extends React.Component<{
+    observerData: ObserverData;
+    setProperty: SetProperty;
+}> {
+    shouldComponentUpdate(
+        nextProps: Readonly<{
+            observerData: ObserverData;
+            setProperty: SetProperty;
+        }>
+    ): boolean {
+        return (
+            JSON.stringify(nextProps.observerData.debug) !== JSON.stringify(this.props.observerData.debug) ||
+            JSON.stringify(nextProps.observerData.ui) !== JSON.stringify(this.props.observerData.ui) ||
+            nextProps.observerData.enableWebGPU !== this.props.observerData.enableWebGPU ||
+            nextProps.observerData.runtime.activeDeviceType !== this.props.observerData.runtime.activeDeviceType
+        );
     }
 
     render() {
@@ -264,20 +325,20 @@ class SettingsPanel extends React.Component <{
         const debugData = props.observerData.debug;
         const activeDevice = props.observerData.runtime.activeDeviceType;
         return (
-            <div className='popup-panel-parent'>
-                <Container class='popup-panel' flex hidden={props.observerData.ui.active !== 'settings'}>
-                    <Label text='Settings' class='popup-panel-heading' />
-                    <Detail label='Current Device' value={activeDevice === 'webgpu' ? 'WebGPU' : 'WebGL 2'} />
+            <div className="popup-panel-parent">
+                <Container class="popup-panel" flex hidden={props.observerData.ui.active !== 'settings'}>
+                    <Label text="Settings" class="popup-panel-heading" />
+                    <Detail label="Current Device" value={activeDevice === 'webgpu' ? 'WebGPU' : 'WebGL 2'} />
                     <Toggle
-                        label='Use WebGPU'
+                        label="Use WebGPU"
                         value={props.observerData.enableWebGPU}
                         enabled={navigator.gpu !== undefined}
                         setProperty={(value: boolean) => {
                             if (value === props.observerData.enableWebGPU) return;
-                            const message = value ?
-                                'Enable WebGPU? The page will refresh to apply this change.' :
-                                'Disable WebGPU? The page will refresh to apply this change.';
-                             
+                            const message = value
+                                ? 'Enable WebGPU? The page will refresh to apply this change.'
+                                : 'Disable WebGPU? The page will refresh to apply this change.';
+
                             if (window.confirm(message)) {
                                 props.setProperty('enableWebGPU', value);
                                 setTimeout(() => window.location.reload(), 100);
@@ -289,42 +350,51 @@ class SettingsPanel extends React.Component <{
                         }}
                     />
                     <Select
-                        label='Render Mode'
-                        type='string'
+                        label="Render Mode"
+                        type="string"
                         options={renderModeOptions}
                         value={debugData.renderMode}
-                        setProperty={(value: string) => props.setProperty('debug.renderMode', value)} />
+                        setProperty={(value: string) => props.setProperty('debug.renderMode', value)}
+                    />
                     <ToggleColor
-                        label='Wireframe'
+                        label="Wireframe"
                         booleanValue={debugData.wireframe}
                         setBooleanProperty={(value: boolean) => props.setProperty('debug.wireframe', value)}
                         colorValue={rgbToArr(debugData.wireframeColor)}
-                        setColorProperty={(value: number[]) => props.setProperty('debug.wireframeColor', arrToRgb(value))} />
+                        setColorProperty={(value: number[]) =>
+                            props.setProperty('debug.wireframeColor', arrToRgb(value))
+                        }
+                    />
                     <Toggle
-                        label='Grid'
+                        label="Grid"
                         value={debugData.grid}
-                        setProperty={(value: boolean) => props.setProperty('debug.grid', value)}/>
+                        setProperty={(value: boolean) => props.setProperty('debug.grid', value)}
+                    />
                     <Toggle
-                        label='Axes'
+                        label="Axes"
                         value={debugData.axes}
-                        setProperty={(value: boolean) => props.setProperty('debug.axes', value)} />
+                        setProperty={(value: boolean) => props.setProperty('debug.axes', value)}
+                    />
                     <Toggle
-                        label='Skeleton'
+                        label="Skeleton"
                         value={debugData.skeleton}
-                        setProperty={(value: boolean) => props.setProperty('debug.skeleton', value)} />
+                        setProperty={(value: boolean) => props.setProperty('debug.skeleton', value)}
+                    />
                     <Toggle
-                        label='Bounds'
+                        label="Bounds"
                         value={debugData.bounds}
-                        setProperty={(value: boolean) => props.setProperty('debug.bounds', value)} />
+                        setProperty={(value: boolean) => props.setProperty('debug.bounds', value)}
+                    />
                     <Slider
-                        label='Normals'
+                        label="Normals"
                         precision={2}
                         min={0}
                         max={1}
                         setProperty={(value: number) => props.setProperty('debug.normals', value)}
-                        value={debugData.normals} />
+                        value={debugData.normals}
+                    />
                     <Toggle
-                        label='Stats'
+                        label="Stats"
                         value={debugData.stats}
                         setProperty={(value: boolean) => props.setProperty('debug.stats', value)}
                     />
@@ -334,11 +404,12 @@ class SettingsPanel extends React.Component <{
     }
 }
 
-class ViewPanel extends React.Component <{
-    sceneData: ObserverData['scene'],
-    uiData: ObserverData['ui'],
-    runtimeData: ObserverData['runtime'],
-    setProperty: SetProperty }> {
+class ViewPanel extends React.Component<{
+    sceneData: ObserverData['scene'];
+    uiData: ObserverData['ui'];
+    runtimeData: ObserverData['runtime'];
+    setProperty: SetProperty;
+}> {
     isMobile: boolean;
 
     get shareUrl() {
@@ -347,15 +418,20 @@ class ViewPanel extends React.Component <{
 
     constructor(props: any) {
         super(props);
-        this.isMobile = (/Android|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
+        this.isMobile = /Android|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
     }
 
-    shouldComponentUpdate(nextProps: Readonly<{
-        sceneData: ObserverData['scene'];
-        uiData: ObserverData['ui'];
-        setProperty: SetProperty; }>): boolean {
-        return JSON.stringify(nextProps.sceneData) !== JSON.stringify(this.props.sceneData) ||
-               JSON.stringify(nextProps.uiData) !== JSON.stringify(this.props.uiData);
+    shouldComponentUpdate(
+        nextProps: Readonly<{
+            sceneData: ObserverData['scene'];
+            uiData: ObserverData['ui'];
+            setProperty: SetProperty;
+        }>
+    ): boolean {
+        return (
+            JSON.stringify(nextProps.sceneData) !== JSON.stringify(this.props.sceneData) ||
+            JSON.stringify(nextProps.uiData) !== JSON.stringify(this.props.uiData)
+        );
     }
 
     get hasQRCode() {
@@ -386,27 +462,32 @@ class ViewPanel extends React.Component <{
     render() {
         const props = this.props;
         return (
-            <div className='popup-panel-parent'>
-                <Container id='view-panel' class='popup-panel' flex hidden={props.uiData.active !== 'view'}>
-                    { this.hasQRCode ?
+            <div className="popup-panel-parent">
+                <Container id="view-panel" class="popup-panel" flex hidden={props.uiData.active !== 'view'}>
+                    {this.hasQRCode ? (
                         <>
-                            <Label text='View and share on mobile with QR code' />
-                            <div id='qr-wrapper'>
-                                <canvas id='share-qr' />
+                            <Label text="View and share on mobile with QR code" />
+                            <div id="qr-wrapper">
+                                <canvas id="share-qr" />
                             </div>
-                            <Label text='View and share on mobile with URL' />
-                            <div id='share-url-wrapper'>
-                                <TextInput class='secondary' value={this.shareUrl} enabled={false} />
-                                <Button id='copy-button' icon='E126' onClick={() => {
-                                    if (navigator.clipboard && window.isSecureContext) {
-                                        navigator.clipboard.writeText(this.shareUrl);
-                                    }
-                                }}/>
+                            <Label text="View and share on mobile with URL" />
+                            <div id="share-url-wrapper">
+                                <TextInput class="secondary" value={this.shareUrl} enabled={false} />
+                                <Button
+                                    id="copy-button"
+                                    icon="E126"
+                                    onClick={() => {
+                                        if (navigator.clipboard && window.isSecureContext) {
+                                            navigator.clipboard.writeText(this.shareUrl);
+                                        }
+                                    }}
+                                />
                             </div>
-                        </> : null }
+                        </>
+                    ) : null}
                     <Button
-                        class='secondary'
-                        text='TAKE A SNAPSHOT AS PNG'
+                        class="secondary"
+                        text="TAKE A SNAPSHOT AS PNG"
                         onClick={() => {
                             if (window.viewer) window.viewer.downloadPngScreenshot();
                         }}
@@ -417,10 +498,4 @@ class ViewPanel extends React.Component <{
     }
 }
 
-export {
-    CameraPanel,
-    SkyboxPanel,
-    LightPanel,
-    SettingsPanel,
-    ViewPanel
-};
+export { CameraPanel, SkyboxPanel, LightPanel, SettingsPanel, ViewPanel };

--- a/src/ui/selected-node.tsx
+++ b/src/ui/selected-node.tsx
@@ -2,6 +2,7 @@ import { Container } from '@playcanvas/pcui/react';
 import React from 'react';
 
 import { SetProperty, ObserverData } from '../types';
+
 import { Vector, Detail } from './components';
 
 class SelectedNode extends React.Component < { sceneData: ObserverData['scene'] } > {

--- a/src/ui/selected-node.tsx
+++ b/src/ui/selected-node.tsx
@@ -1,12 +1,14 @@
 import { Container } from '@playcanvas/pcui/react';
 import React from 'react';
 
-import { SetProperty, ObserverData } from '../types';
+import type { SetProperty, ObserverData } from '../types';
 
 import { Vector, Detail } from './components';
 
-class SelectedNode extends React.Component < { sceneData: ObserverData['scene'] } > {
-    shouldComponentUpdate(nextProps: Readonly<{ sceneData: ObserverData['scene']; setProperty: SetProperty; }>): boolean {
+class SelectedNode extends React.Component<{ sceneData: ObserverData['scene'] }> {
+    shouldComponentUpdate(
+        nextProps: Readonly<{ sceneData: ObserverData['scene']; setProperty: SetProperty }>
+    ): boolean {
         return (
             nextProps.sceneData.nodes !== this.props.sceneData.nodes ||
             nextProps.sceneData.selectedNode.path !== this.props.sceneData.selectedNode.path ||
@@ -22,12 +24,12 @@ class SelectedNode extends React.Component < { sceneData: ObserverData['scene'] 
         const hasHierarchy = scene.nodes !== '[]';
         const nodeSelected = scene.selectedNode.path;
         return hasHierarchy && nodeSelected ? (
-            <div className='selected-node-panel-parent'>
-                <Container class='selected-node-panel' flex>
-                    <Detail label='Name' value={scene.selectedNode.name} />
-                    <Vector label='Position' dimensions={3} value={scene.selectedNode.position} enabled={false}/>
-                    <Vector label='Rotation' dimensions={3} value={scene.selectedNode.rotation} enabled={false}/>
-                    <Vector label='Scale' dimensions={3} value={scene.selectedNode.scale} enabled={false}/>
+            <div className="selected-node-panel-parent">
+                <Container class="selected-node-panel" flex>
+                    <Detail label="Name" value={scene.selectedNode.name} />
+                    <Vector label="Position" dimensions={3} value={scene.selectedNode.position} enabled={false} />
+                    <Vector label="Rotation" dimensions={3} value={scene.selectedNode.rotation} enabled={false} />
+                    <Vector label="Scale" dimensions={3} value={scene.selectedNode.scale} enabled={false} />
                 </Container>
             </div>
         ) : null;

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,4 +1,17 @@
-import { Observer } from '@playcanvas/observer';
+import type { Observer } from '@playcanvas/observer';
+import type {
+    AnimTrack,
+    ContainerResource,
+    GraphicsDevice,
+    GraphNode,
+    GSplatComponent,
+    GSplatData,
+    Mesh,
+    MorphInstance,
+    MorphTarget,
+    RenderComponent,
+    CameraComponent
+} from 'playcanvas';
 import {
     ADDRESS_CLAMP_TO_EDGE,
     BLENDMODE_ONE,
@@ -36,37 +49,28 @@ import {
     path,
     platform,
     AnimEvents,
-    AnimTrack,
     Asset,
     BlendState,
     BoundingBox,
     Color,
-    ContainerResource,
     Entity,
     EnvLighting,
-    GraphicsDevice,
-    GraphNode,
-    GSplatComponent,
-    GSplatData,
     GSplatResource,
     Keyboard,
     Mat4,
-    Mesh,
     MeshInstance,
-    MorphInstance,
-    MorphTarget,
     Mouse,
     MiniStats,
     Quat,
-    RenderComponent,
     RenderTarget,
     StandardMaterial,
     Texture,
     TouchDevice,
     Vec3,
-    Vec2,
-    CameraComponent
+    Vec2
 } from 'playcanvas';
+
+import { MeshoptDecoder } from '../lib/meshopt_decoder.module.js';
 
 import { App } from './app';
 import { CameraControls } from './camera-controls';
@@ -76,9 +80,8 @@ import { Multiframe } from './multiframe';
 import { Picker } from './picker';
 import { PngExporter } from './png-exporter';
 import { ShadowCatcher } from './shadow-catcher';
-import { File, HierarchyNode, MorphTargetData, SceneCamera } from './types';
+import type { File, HierarchyNode, MorphTargetData, SceneCamera } from './types';
 import { XRObjectPlacementController } from './xr-mode';
-import { MeshoptDecoder } from '../lib/meshopt_decoder.module.js';
 
 // model filename extensions
 const modelExtensions = ['gltf', 'glb', 'vox'];
@@ -115,19 +118,19 @@ class Viewer {
 
     debugRoot: Entity;
 
-    entities: Array<Entity>;
+    entities: Entity[];
 
-    entityAssets: Array<{ entity: Entity; asset: Asset }>;
+    entityAssets: { entity: Entity; asset: Asset }[];
 
-    assets: Array<Asset>;
+    assets: Asset[];
 
-    meshInstances: Array<MeshInstance>;
+    meshInstances: MeshInstance[];
 
-    wireframeMeshInstances: Array<MeshInstance>;
+    wireframeMeshInstances: MeshInstance[];
 
     wireframeMaterial: StandardMaterial;
 
-    animTracks: Array<AnimTrack>;
+    animTracks: AnimTrack[];
 
     animationMap: Record<string, string>;
 
@@ -201,7 +204,7 @@ class Viewer {
 
     cameraControls: CameraControls;
 
-    sceneCameras: Array<CameraComponent> = [];
+    sceneCameras: CameraComponent[] = [];
 
     activeSceneCamera: CameraComponent | null = null;
 
@@ -252,7 +255,7 @@ class Viewer {
         observer.set('camera.multisample', multisampleSupported && observer.get('camera.multisample'));
 
         // create drop handler
-        CreateDropHandler(document.getElementById('app'), (files: Array<File>, resetScene: boolean) => {
+        CreateDropHandler(document.getElementById('app'), (files: File[], resetScene: boolean) => {
             this.loadFiles(files, resetScene);
         });
 
@@ -503,7 +506,7 @@ class Viewer {
 
     // collects all mesh instances from entity hierarchy
     private collectMeshInstances(entity: Entity) {
-        const meshInstances: Array<MeshInstance> = [];
+        const meshInstances: MeshInstance[] = [];
         if (entity) {
             const components = entity.findComponents('render');
             for (let i = 0; i < components.length; i++) {
@@ -528,7 +531,7 @@ class Viewer {
     }
 
     // calculate the bounding box of the given mesh
-    private static calcMeshBoundingBox(result: BoundingBox, meshInstances: Array<MeshInstance>) {
+    private static calcMeshBoundingBox(result: BoundingBox, meshInstances: MeshInstance[]) {
         if (meshInstances.length > 0) {
             result.copy(meshInstances[0].aabb);
             for (let i = 1; i < meshInstances.length; ++i) {
@@ -688,7 +691,7 @@ class Viewer {
 
     // load the image files into the skybox. this function supports loading a single equirectangular
     // skybox image or 6 cubemap faces.
-    private loadSkybox(files: Array<File>) {
+    private loadSkybox(files: File[]) {
         const app = this.app;
 
         if (files.length !== 6) {
@@ -988,7 +991,7 @@ class Viewer {
             }
         });
 
-        const mapChildren = function (node: GraphNode): Array<HierarchyNode> {
+        const mapChildren = function (node: GraphNode): HierarchyNode[] {
             return node.children.map((child: GraphNode) => ({
                 name: child.name,
                 path: child.path,
@@ -996,7 +999,7 @@ class Viewer {
             }));
         };
 
-        const graph: Array<HierarchyNode> = this.entities.map((entity) => {
+        const graph: HierarchyNode[] = this.entities.map((entity) => {
             return {
                 name: entity.name,
                 path: entity.path,
@@ -1021,7 +1024,7 @@ class Viewer {
         this.observer.set('scene.variant.selected', variants[0]);
 
         // detect cameras in the loaded scene
-        const cameras: Array<SceneCamera> = [];
+        const cameras: SceneCamera[] = [];
 
         this.entities.forEach((entity) => {
             const cameraComponents = entity.findComponents('camera') as CameraComponent[];
@@ -1101,13 +1104,13 @@ class Viewer {
     }
 
     // load gltf model given its url and list of external urls
-    private loadGltf(gltfUrl: File, externalUrls: Array<File>, warnings: string[]) {
+    private loadGltf(gltfUrl: File, externalUrls: File[], warnings: string[]) {
         return new Promise((resolve, reject) => {
             // provide buffer view callback so we can handle models compressed with MeshOptimizer
             // https://github.com/zeux/meshoptimizer
             const processBufferView = (
                 gltfBuffer: any,
-                buffers: Array<any>,
+                buffers: any[],
                 continuation: (err: string, result: any) => void
             ) => {
                 if (gltfBuffer.extensions && gltfBuffer.extensions.EXT_meshopt_compression) {
@@ -1258,7 +1261,7 @@ class Viewer {
         });
     }
 
-    private loadPly(url: File, externalUrls: Array<File>) {
+    private loadPly(url: File, externalUrls: File[]) {
         const urls: any = {};
         externalUrls.forEach((url) => {
             urls[url.filename] = url.url;
@@ -1291,7 +1294,7 @@ class Viewer {
     // load the list of urls.
     // urls can reference glTF files, glb files and skybox textures.
     // returns true if a model was loaded.
-    loadFiles(files: Array<File>, resetScene = false) {
+    loadFiles(files: File[], resetScene = false) {
         // convert single url to list
         if (!Array.isArray(files)) {
             files = [files];

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -94,6 +94,29 @@ const bbox = new BoundingBox();
 const FOCUS_FOV = 75;
 const ZOOM_SCALE_MIN = 0.01;
 
+type LoaderCallback<T> = (err: string | null, result: T | null) => void;
+type GltfResource = { uri?: string };
+type GltfBufferView = {
+    extensions?: {
+        EXT_meshopt_compression?: {
+            buffer: number;
+            byteOffset?: number;
+            byteLength?: number;
+            count: number;
+            byteStride: number;
+            mode: string;
+            filter: string;
+        };
+    };
+};
+type RenderResource = { meshes: Mesh[] };
+type ContainerStatsResource = ContainerResource & { renders: Asset[]; materials: unknown[]; textures: Asset[] };
+type SceneResource = {
+    renders?: Asset[];
+    animations?: Asset[];
+    instantiateRenderEntity: () => Entity;
+};
+
 class Viewer {
     canvas: HTMLCanvasElement;
 
@@ -577,7 +600,7 @@ class Viewer {
 
     // construct the controls interface and initialize controls
     private bindControlEvents() {
-        const controlEvents: Record<string, (...args: any[]) => void> = {
+        const controlEvents: Record<string, (...args: never[]) => void> = {
             // camera
             'camera.fov': this.setFov.bind(this),
             'camera.tonemapping': this.setTonemapping.bind(this),
@@ -951,12 +974,12 @@ class Viewer {
                 }
             } else {
                 // ContainerResource type isn't picked up correctly for some reason
-                const resource = asset.resource as any;
+                const resource = asset.resource as ContainerStatsResource;
 
                 variants = variants.concat(resource.getMaterialVariants() ?? []);
 
                 resource.renders.forEach((renderAsset: Asset) => {
-                    const res = renderAsset.resource as any;
+                    const res = renderAsset.resource as RenderResource;
                     meshCount += res.meshes.length;
                     res.meshes.forEach((mesh: Mesh) => {
                         vertexCount += mesh.vertexBuffer.getNumVertices();
@@ -1118,9 +1141,9 @@ class Viewer {
             // provide buffer view callback so we can handle models compressed with MeshOptimizer
             // https://github.com/zeux/meshoptimizer
             const processBufferView = (
-                gltfBuffer: any,
-                buffers: any[],
-                continuation: (err: string, result: any) => void
+                gltfBuffer: GltfBufferView,
+                buffers: ArrayBufferView[],
+                continuation: LoaderCallback<Uint8Array>
             ) => {
                 if (gltfBuffer.extensions && gltfBuffer.extensions.EXT_meshopt_compression) {
                     const extensionDef = gltfBuffer.extensions.EXT_meshopt_compression;
@@ -1178,7 +1201,7 @@ class Viewer {
                 return asset;
             };
 
-            const processImage = (gltfImage: any, continuation: (err: string, result: any) => void) => {
+            const processImage = (gltfImage: GltfResource, continuation: LoaderCallback<Asset>) => {
                 const u: File = externalUrls.find((url) => {
                     return url.filename === decodeURIComponent(path.normalize(gltfImage.uri || ''));
                 });
@@ -1206,7 +1229,7 @@ class Viewer {
                 }
             };
 
-            const postProcessTexture = (gltfTexture: any, textureAsset: Asset) => {
+            const postProcessTexture = (gltfTexture: unknown, textureAsset: Asset) => {
                 // Set max anisotropy only for textures that use linear filtering, as anisotropic
                 // filtering only makes sense with linear filtering modes
                 const texture = textureAsset.resource as Texture;
@@ -1215,7 +1238,7 @@ class Viewer {
                 }
             };
 
-            const processBuffer = (gltfBuffer: any, continuation: (err: string, result: any) => void) => {
+            const processBuffer = (gltfBuffer: GltfResource, continuation: LoaderCallback<Uint8Array>) => {
                 const u = externalUrls.find((url) => {
                     return url.filename === decodeURIComponent(path.normalize(gltfBuffer.uri || ''));
                 });
@@ -1278,7 +1301,7 @@ class Viewer {
     }
 
     private loadPly(url: File, externalUrls: File[]) {
-        const urls: any = {};
+        const urls: Record<string, string> = {};
         externalUrls.forEach((url) => {
             urls[url.filename] = url.url;
         });
@@ -1721,7 +1744,7 @@ class Viewer {
             ACES2: TONEMAP_ACES2
         };
 
-        this.camera.camera.toneMapping = Object.prototype.hasOwnProperty.call(mapping, tonemapping)
+        this.camera.camera.toneMapping = Reflect.apply(mapping.hasOwnProperty, mapping, [tonemapping])
             ? mapping[tonemapping]
             : TONEMAP_ACES;
         this.renderNextFrame();
@@ -1800,7 +1823,7 @@ class Viewer {
     // add a loaded asset to the scene
     // asset is a container asset with renders and/or animations
     private addToScene(asset: Asset) {
-        const resource = asset.resource as any;
+        const resource = asset.resource as SceneResource;
         const meshesLoaded = resource.renders && resource.renders.length > 0;
         const animsLoaded = resource.animations && resource.animations.length > 0;
         const prevEntity: Entity = this.entities.length === 0 ? null : this.entities[this.entities.length - 1];
@@ -1815,7 +1838,7 @@ class Viewer {
                 // container/glb
                 entity = resource.instantiateRenderEntity();
             } else {
-                const unified = ((asset.file as any)?.filename ?? '').endsWith('lod-meta.json');
+                const unified = ((asset.file as { filename?: string })?.filename ?? '').endsWith('lod-meta.json');
 
                 // gaussian splat scene
                 entity = new Entity();
@@ -1841,8 +1864,8 @@ class Viewer {
         // create animation component
         if (animsLoaded) {
             // append anim tracks to global list
-            resource.animations.forEach((a: any) => {
-                this.animTracks.push(a.resource);
+            resource.animations.forEach((a) => {
+                this.animTracks.push(a.resource as AnimTrack);
             });
         }
 
@@ -1953,13 +1976,13 @@ class Viewer {
         this.animationMap = {};
         // Build unique display names for animations (handle duplicate names)
         const nameCounts = new Map<string, number>();
-        this.animTracks.forEach((t: any) => {
+        this.animTracks.forEach((t) => {
             nameCounts.set(t.name, (nameCounts.get(t.name) ?? 0) + 1);
         });
 
         // If there are duplicates, append index to make names unique
         const nameIndices = new Map<string, number>();
-        const uniqueDisplayNames: string[] = this.animTracks.map((t: any) => {
+        const uniqueDisplayNames: string[] = this.animTracks.map((t) => {
             const name = t.name;
             if (nameCounts.get(name) > 1) {
                 const index = nameIndices.get(name) ?? 0;
@@ -1982,7 +2005,7 @@ class Viewer {
                 entity.anim.removeStateGraph();
             }
 
-            this.animTracks.forEach((t: any, i: number) => {
+            this.animTracks.forEach((t, i) => {
                 // add an event to each track which transitions to the next track when it ends
                 t.events = new AnimEvents([
                     {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -95,6 +95,8 @@ const FOCUS_FOV = 75;
 const ZOOM_SCALE_MIN = 0.01;
 
 type LoaderCallback<T> = (err: string | null, result: T | null) => void;
+type MoveDevice = { _moveHandler: (event: MouseEvent) => void };
+type AssetOptions = NonNullable<ConstructorParameters<typeof Asset>[4]>;
 type GltfResource = { uri?: string };
 type GltfBufferView = {
     extensions?: {
@@ -255,29 +257,24 @@ class Viewer {
 
         // monkeypatch the mouse and touch input devices to ignore touch events
         // when they don't originate from the canvas.
-        // @ts-expect-error engine-private handler override
-        const origMouseHandler = app.mouse._moveHandler;
+        const origMouseHandler = (app.mouse as unknown as MoveDevice)._moveHandler;
         app.mouse.detach();
-        // @ts-expect-error engine-private handler override
-        app.mouse._moveHandler = (event: MouseEvent) => {
+        (app.mouse as unknown as MoveDevice)._moveHandler = (event: MouseEvent) => {
             if (event.target === canvas) {
                 origMouseHandler(event);
             }
         };
         app.mouse.attach(canvas);
 
-        // @ts-expect-error engine-private handler override
-        const origTouchHandler = app.touch._moveHandler;
+        const origTouchHandler = (app.touch as unknown as MoveDevice)._moveHandler;
         app.touch.detach();
-        // @ts-expect-error engine-private handler override
-        app.touch._moveHandler = (event: MouseEvent) => {
+        (app.touch as unknown as MoveDevice)._moveHandler = (event: MouseEvent) => {
             if (event.target === canvas) {
                 origTouchHandler(event);
             }
         };
         app.touch.attach(canvas);
 
-        // @ts-ignore
         const multisampleSupported = app.graphicsDevice.maxSamples > 1;
         observer.set('camera.multisampleSupported', multisampleSupported);
         observer.set('camera.multisample', multisampleSupported && observer.get('camera.multisample'));
@@ -900,7 +897,6 @@ class Viewer {
             });
         };
 
-        // @ts-ignore
         const maxSamples = device.maxSamples;
 
         // in with the new
@@ -1279,7 +1275,6 @@ class Viewer {
             };
 
             const containerAsset = new Asset(gltfUrl.filename, 'container', gltfUrl, null, {
-                // @ts-ignore TODO no definition in pc
                 bufferView: {
                     processAsync: processBufferView
                 },
@@ -1292,6 +1287,11 @@ class Viewer {
                 buffer: {
                     processAsync: processBuffer
                 }
+            } as AssetOptions & {
+                bufferView: { processAsync: typeof processBufferView };
+                image: { processAsync: typeof processImage };
+                texture: { postprocess: typeof postProcessTexture };
+                buffer: { processAsync: typeof processBuffer };
             });
             containerAsset.on('load', () => resolve(containerAsset));
             containerAsset.on('error', (err: string) => reject(err));
@@ -1307,9 +1307,8 @@ class Viewer {
         });
         return new Promise((resolve, reject) => {
             const asset = new Asset(url.filename, 'gsplat', url, null, {
-                // @ts-ignore TODO no definition in pc
                 mapUrl: (mapUrl) => urls[mapUrl]
-            });
+            } as AssetOptions & { mapUrl: (url: string) => string });
             asset.on('load', () => resolve(asset));
             asset.on('error', (err: string) => reject(err));
             this.app.assets.add(asset);
@@ -2170,8 +2169,9 @@ class Viewer {
                 for (let i = 0; i < this.meshInstances.length; ++i) {
                     const meshInstance = this.meshInstances[i];
 
-                    const vertexBuffer = meshInstance.morphInstance // @ts-ignore TODO not defined in pc
-                        ? meshInstance.morphInstance._vertexBuffer
+                    const vertexBuffer = meshInstance.morphInstance
+                        ? (meshInstance.morphInstance as unknown as { _vertexBuffer: Mesh['vertexBuffer'] })
+                              ._vertexBuffer
                         : meshInstance.mesh.vertexBuffer;
 
                     if (vertexBuffer) {
@@ -2180,8 +2180,11 @@ class Viewer {
                         // if there is skinning we need to manually update matrices here otherwise
                         // our normals are always a frame behind
                         if (skinMatrices) {
-                            // @ts-ignore TODO not defined in pc
-                            meshInstance.skinInstance.updateMatrices(meshInstance.node);
+                            (
+                                meshInstance.skinInstance as unknown as {
+                                    updateMatrices: (node: GraphNode) => void;
+                                }
+                            ).updateMatrices(meshInstance.node);
                         }
 
                         this.debugNormals.generateNormals(

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -70,8 +70,6 @@ import {
     Vec2
 } from 'playcanvas';
 
-import { MeshoptDecoder } from '../lib/meshopt_decoder.module.js';
-
 import { App } from './app';
 import { CameraControls } from './camera-controls';
 import { DebugLines } from './debug-lines';
@@ -82,6 +80,9 @@ import { PngExporter } from './png-exporter';
 import { ShadowCatcher } from './shadow-catcher';
 import type { File, HierarchyNode, MorphTargetData, SceneCamera } from './types';
 import { XRObjectPlacementController } from './xr-mode';
+
+// eslint-disable-next-line import-x/order -- preserve module initialization order
+import { MeshoptDecoder } from '../lib/meshopt_decoder.module.js';
 
 // model filename extensions
 const modelExtensions = ['gltf', 'glb', 'vox'];
@@ -231,8 +232,10 @@ class Viewer {
 
         // monkeypatch the mouse and touch input devices to ignore touch events
         // when they don't originate from the canvas.
+        // @ts-expect-error engine-private handler override
         const origMouseHandler = app.mouse._moveHandler;
         app.mouse.detach();
+        // @ts-expect-error engine-private handler override
         app.mouse._moveHandler = (event: MouseEvent) => {
             if (event.target === canvas) {
                 origMouseHandler(event);
@@ -240,8 +243,10 @@ class Viewer {
         };
         app.mouse.attach(canvas);
 
+        // @ts-expect-error engine-private handler override
         const origTouchHandler = app.touch._moveHandler;
         app.touch.detach();
+        // @ts-expect-error engine-private handler override
         app.touch._moveHandler = (event: MouseEvent) => {
             if (event.target === canvas) {
                 origTouchHandler(event);
@@ -426,11 +431,12 @@ class Viewer {
         canvas.addEventListener('pointerdown', async (event) => {
             const now = Date.now();
             const delay = Math.max(0, now - lastTap.time);
-            if (delay < 300 &&
-                Math.abs(event.clientX - lastTap.x) < 8 &&
-                Math.abs(event.clientY - lastTap.y) < 8) {
+            if (delay < 300 && Math.abs(event.clientX - lastTap.x) < 8 && Math.abs(event.clientY - lastTap.y) < 8) {
                 lastTap.time = 0;
-                const result = await this.picker.pick(event.offsetX / canvas.clientWidth, event.offsetY / canvas.clientHeight);
+                const result = await this.picker.pick(
+                    event.offsetX / canvas.clientWidth,
+                    event.offsetY / canvas.clientHeight
+                );
                 if (result) {
                     this.cameraControls.reset(result, this.camera.getPosition());
                 }
@@ -756,7 +762,7 @@ class Viewer {
 
             // construct the cubemap asset
             const cubemapAsset = new Asset('skybox_cubemap', 'cubemap', null, {
-                textures: faceAssets.map(faceAsset => faceAsset.id)
+                textures: faceAssets.map((faceAsset) => faceAsset.id)
             });
             cubemapAsset.loadFaces = true;
             cubemapAsset.on('load', () => {
@@ -1063,16 +1069,19 @@ class Viewer {
         this.renderNextFrame();
         this.app.once('postrender', () => {
             const texture = this.camera.camera.renderTarget.colorBuffer;
-            texture.read(0, 0, texture.width, texture.height).then((typedArray: Uint32Array) => {
-                this.pngExporter.export(
-                    `${filename}.png`,
-                    new Uint32Array(typedArray.buffer.slice(0)),
-                    texture.width,
-                    texture.height
-                );
-            }).catch((err: unknown) => {
-                console.error('Failed to capture PNG screenshot from render target:', err);
-            });
+            texture
+                .read(0, 0, texture.width, texture.height)
+                .then((typedArray: Uint32Array) => {
+                    this.pngExporter.export(
+                        `${filename}.png`,
+                        new Uint32Array(typedArray.buffer.slice(0)),
+                        texture.width,
+                        texture.height
+                    );
+                })
+                .catch((err: unknown) => {
+                    console.error('Failed to capture PNG screenshot from render target:', err);
+                });
         });
     }
 
@@ -1156,7 +1165,7 @@ class Viewer {
                 const pixels = texture.lock();
                 for (let i = 0; i < 4; i++) {
                     pixels[i * 4 + 0] = 255; // R
-                    pixels[i * 4 + 1] = 0;   // G
+                    pixels[i * 4 + 1] = 0; // G
                     pixels[i * 4 + 2] = 255; // B
                     pixels[i * 4 + 3] = 255; // A
                 }
@@ -1226,13 +1235,20 @@ class Viewer {
                 } else if (gltfBuffer.uri && !gltfBuffer.uri.startsWith('data:')) {
                     // External buffer file referenced but not provided
                     // Check if only the current .gltf file was dragged (no other files provided)
-                    const onlyGltfFile = externalUrls.length === 1 &&
+                    const onlyGltfFile =
+                        externalUrls.length === 1 &&
                         this.isModelFilename(externalUrls[0].filename) &&
                         externalUrls[0].filename === gltfUrl.filename;
                     if (onlyGltfFile) {
-                        continuation(`External buffer file '${gltfBuffer.uri}' not found. Try dragging the folder containing the .gltf file instead of the file itself.`, null);
+                        continuation(
+                            `External buffer file '${gltfBuffer.uri}' not found. Try dragging the folder containing the .gltf file instead of the file itself.`,
+                            null
+                        );
                     } else {
-                        continuation(`External buffer file not found: '${gltfBuffer.uri}'. Make sure to include the associated .bin file(s).`, null);
+                        continuation(
+                            `External buffer file not found: '${gltfBuffer.uri}'. Make sure to include the associated .bin file(s).`,
+                            null
+                        );
                     }
                 } else {
                     continuation(null, null);
@@ -1269,7 +1285,7 @@ class Viewer {
         return new Promise((resolve, reject) => {
             const asset = new Asset(url.filename, 'gsplat', url, null, {
                 // @ts-ignore TODO no definition in pc
-                mapUrl: mapUrl => urls[mapUrl]
+                mapUrl: (mapUrl) => urls[mapUrl]
             });
             asset.on('load', () => resolve(asset));
             asset.on('error', (err: string) => reject(err));
@@ -1323,53 +1339,53 @@ class Viewer {
 
             // load asset files
             const promises = files.map((file) => {
-                return this.isModelFilename(file.filename) ?
-                    this.loadGltf(file, files, warnings) :
-                    this.isGSplatFilename(file.filename) ?
-                        this.loadPly(file, files) :
-                        null;
+                return this.isModelFilename(file.filename)
+                    ? this.loadGltf(file, files, warnings)
+                    : this.isGSplatFilename(file.filename)
+                      ? this.loadPly(file, files)
+                      : null;
             });
 
             Promise.all(promises)
-            .then((assets: Asset[]) => {
-                this.loadTimestamp = loadTimestamp;
+                .then((assets: Asset[]) => {
+                    this.loadTimestamp = loadTimestamp;
 
-                // add assets to the scene
-                assets.forEach((asset) => {
-                    if (asset) {
-                        this.addToScene(asset);
+                    // add assets to the scene
+                    assets.forEach((asset) => {
+                        if (asset) {
+                            this.addToScene(asset);
+                        }
+                    });
+
+                    // prepare scene post load
+                    this.postSceneLoad();
+
+                    // update scene urls
+                    const urls = files.map((f) => f.url);
+                    const filenames = files.map((f) => f.filename.split('/').pop());
+                    if (resetScene) {
+                        this.observer.set('scene.urls', urls);
+                        this.observer.set('scene.filenames', filenames);
+                    } else {
+                        this.observer.set('scene.urls', this.observer.get('scene.urls').concat(urls));
+                        this.observer.set('scene.filenames', this.observer.get('scene.filenames').concat(filenames));
                     }
+
+                    // Show any warnings that occurred during loading
+                    if (warnings.length > 0) {
+                        // Log all warnings to console for full details
+                        console.warn(`Model loaded with ${warnings.length} warning(s):`);
+                        warnings.forEach((w) => console.warn(`  - ${w}`));
+                        this.observer.set('ui.warnings', warnings);
+                    }
+                })
+                .catch((err) => {
+                    console.log(err);
+                    this.observer.set('ui.error', err?.toString() || err);
+                })
+                .finally(() => {
+                    this.observer.set('ui.spinner', false);
                 });
-
-                // prepare scene post load
-                this.postSceneLoad();
-
-                // update scene urls
-                const urls = files.map(f => f.url);
-                const filenames = files.map(f => f.filename.split('/').pop());
-                if (resetScene) {
-                    this.observer.set('scene.urls', urls);
-                    this.observer.set('scene.filenames', filenames);
-                } else {
-                    this.observer.set('scene.urls', this.observer.get('scene.urls').concat(urls));
-                    this.observer.set('scene.filenames', this.observer.get('scene.filenames').concat(filenames));
-                }
-
-                // Show any warnings that occurred during loading
-                if (warnings.length > 0) {
-                    // Log all warnings to console for full details
-                    console.warn(`Model loaded with ${warnings.length} warning(s):`);
-                    warnings.forEach(w => console.warn(`  - ${w}`));
-                    this.observer.set('ui.warnings', warnings);
-                }
-            })
-            .catch((err) => {
-                console.log(err);
-                this.observer.set('ui.error', err?.toString() || err);
-            })
-            .finally(() => {
-                this.observer.set('ui.spinner', false);
-            });
         } else {
             // load skybox
             this.loadSkybox(files);
@@ -1705,7 +1721,9 @@ class Viewer {
             ACES2: TONEMAP_ACES2
         };
 
-        this.camera.camera.toneMapping = mapping.hasOwnProperty(tonemapping) ? mapping[tonemapping] : TONEMAP_ACES;
+        this.camera.camera.toneMapping = Object.prototype.hasOwnProperty.call(mapping, tonemapping)
+            ? mapping[tonemapping]
+            : TONEMAP_ACES;
         this.renderNextFrame();
     }
 
@@ -1836,10 +1854,10 @@ class Viewer {
     private postSceneLoad() {
         // construct a list of meshInstances so we can quickly access them when configuring wireframe rendering etc.
         this.meshInstances = this.entities
-        .map((entity) => {
-            return this.collectMeshInstances(entity);
-        })
-        .flat();
+            .map((entity) => {
+                return this.collectMeshInstances(entity);
+            })
+            .flat();
 
         // if no meshes are currently loaded, then enable skeleton rendering so user can see something
         if (this.meshInstances.length === 0) {
@@ -2001,7 +2019,11 @@ class Viewer {
 
         let first = true;
 
-        const renderComponents = entities.map(e => e.findComponents('render') as RenderComponent[]).flat().map(rc => rc.meshInstances).flat();
+        const renderComponents = entities
+            .map((e) => e.findComponents('render') as RenderComponent[])
+            .flat()
+            .map((rc) => rc.meshInstances)
+            .flat();
         if (renderComponents.length) {
             for (let i = 0; i < renderComponents.length; ++i) {
                 if (first) {
@@ -2013,10 +2035,16 @@ class Viewer {
             }
         }
 
-        const gsplatComponents = entities.map(e => e.findComponents('gsplat') as GSplatComponent[]).flat().filter(gc => !!gc.customAabb);
+        const gsplatComponents = entities
+            .map((e) => e.findComponents('gsplat') as GSplatComponent[])
+            .flat()
+            .filter((gc) => !!gc.customAabb);
         if (gsplatComponents.length) {
             for (let i = 0; i < gsplatComponents.length; ++i) {
-                bbox.setFromTransformedAabb(gsplatComponents[i].customAabb, gsplatComponents[i].entity.getWorldTransform());
+                bbox.setFromTransformedAabb(
+                    gsplatComponents[i].customAabb,
+                    gsplatComponents[i].entity.getWorldTransform()
+                );
                 if (first) {
                     result.copy(bbox);
                     first = false;
@@ -2119,9 +2147,9 @@ class Viewer {
                 for (let i = 0; i < this.meshInstances.length; ++i) {
                     const meshInstance = this.meshInstances[i];
 
-                    const vertexBuffer = meshInstance.morphInstance ? // @ts-ignore TODO not defined in pc
-                        meshInstance.morphInstance._vertexBuffer :
-                        meshInstance.mesh.vertexBuffer;
+                    const vertexBuffer = meshInstance.morphInstance // @ts-ignore TODO not defined in pc
+                        ? meshInstance.morphInstance._vertexBuffer
+                        : meshInstance.mesh.vertexBuffer;
 
                     if (vertexBuffer) {
                         const skinMatrices = meshInstance.skinInstance ? meshInstance.skinInstance.matrices : null;

--- a/src/xr-mode.ts
+++ b/src/xr-mode.ts
@@ -1,3 +1,11 @@
+import type {
+    Entity,
+    XrHitTestSource,
+    XrManager,
+    MeshInstance,
+    RenderComponent,
+    GSplatComponent
+} from 'playcanvas';
 import {
     XRSPACE_LOCAL,
     XRSPACE_VIEWER,
@@ -6,15 +14,9 @@ import {
     XRTRACKABLE_MESH,
     XRTYPE_AR,
     BoundingBox,
-    Entity,
     EventHandler,
     Vec3,
-    Mat4,
-    XrHitTestSource,
-    XrManager,
-    MeshInstance,
-    RenderComponent,
-    GSplatComponent
+    Mat4
 } from 'playcanvas';
 
 import arCloseImage from './svg/ar-close.svg';
@@ -28,7 +30,7 @@ const mat = new Mat4();
 // modulo dealing with negative numbers
 const mod = (n: number, m: number) => ((n % m) + m) % m;
 
-type TweenValue = {[key: string]: number};
+type TweenValue = Record<string, number>;
 
 // helper tween class
 class Tween {
@@ -84,7 +86,7 @@ class Tween {
     }
 }
 
-interface XRObjectPlacementOptions {
+type XRObjectPlacementOptions = {
     xr: XrManager;
     camera: Entity;
     content: Entity;
@@ -188,14 +190,14 @@ class XRObjectPlacementController {
     // create an invisible dom element for capturing pointer input
     // rotate the model with two finger tap and twist
     private _createRotateInput() {
-        const touches: Map<
+        const touches = new Map<
             number,
             {
                 start: {x: number; y: number};
                 previous: {x: number; y: number};
                 current: {x: number; y: number};
             }
-        > = new Map();
+        >();
         let baseAngle = 0;
         let angle = 0;
 

--- a/src/xr-mode.ts
+++ b/src/xr-mode.ts
@@ -1,11 +1,4 @@
-import type {
-    Entity,
-    XrHitTestSource,
-    XrManager,
-    MeshInstance,
-    RenderComponent,
-    GSplatComponent
-} from 'playcanvas';
+import type { Entity, XrHitTestSource, XrManager, MeshInstance, RenderComponent, GSplatComponent } from 'playcanvas';
 import {
     XRSPACE_LOCAL,
     XRSPACE_VIEWER,
@@ -90,7 +83,7 @@ type XRObjectPlacementOptions = {
     xr: XrManager;
     camera: Entity;
     content: Entity;
-}
+};
 
 class XRObjectPlacementController {
     options: XRObjectPlacementOptions;
@@ -193,9 +186,9 @@ class XRObjectPlacementController {
         const touches = new Map<
             number,
             {
-                start: {x: number; y: number};
-                previous: {x: number; y: number};
-                current: {x: number; y: number};
+                start: { x: number; y: number };
+                previous: { x: number; y: number };
+                current: { x: number; y: number };
             }
         >();
         let baseAngle = 0;
@@ -338,16 +331,17 @@ class XRObjectPlacementController {
         events.on('xr:start', () => {
             hovering = true;
 
-            meshInstances = this.options.content.findComponents('render')
-            .map((render: RenderComponent) => {
-                return render.meshInstances;
-            })
-            .flat()
-            .concat(this.options.content.findComponents('gsplat')
-            .map((gsplat: GSplatComponent) => {
-                return gsplat.instance.meshInstance;
-            })
-            );
+            meshInstances = this.options.content
+                .findComponents('render')
+                .map((render: RenderComponent) => {
+                    return render.meshInstances;
+                })
+                .flat()
+                .concat(
+                    this.options.content.findComponents('gsplat').map((gsplat: GSplatComponent) => {
+                        return gsplat.instance.meshInstance;
+                    })
+                );
 
             updateBound();
 

--- a/src/xr-mode.ts
+++ b/src/xr-mode.ts
@@ -37,13 +37,13 @@ class Tween {
 
     transitionTime = 0;
 
-    constructor(value: any) {
+    constructor(value: TweenValue) {
         this.value = value;
         this.source = { ...value };
         this.target = { ...value };
     }
 
-    goto(target: any, transitionTime = 0.25) {
+    goto(target: TweenValue, transitionTime = 0.25) {
         if (transitionTime === 0) {
             Tween.copy(this.value, target);
         }
@@ -66,13 +66,13 @@ class Tween {
         return Math.pow(n - 1, 5) + 1;
     }
 
-    static copy(target: any, source: any) {
+    static copy(target: TweenValue, source: TweenValue) {
         Object.keys(target).forEach((key: string) => {
             target[key] = source[key];
         });
     }
 
-    static lerp(target: any, a: any, b: any, t: number) {
+    static lerp(target: TweenValue, a: TweenValue, b: TweenValue, t: number) {
         Object.keys(target).forEach((key: string) => {
             target[key] = a[key] + t * (b[key] - a[key]);
         });

--- a/src/xr-mode.ts
+++ b/src/xr-mode.ts
@@ -424,8 +424,10 @@ class XRObjectPlacementController {
             const far = dist + boundRadius;
             const near = Math.max(0.0001, dist < boundRadius ? far / 1024 : dist - boundRadius);
 
-            // @ts-ignore
-            xr._setClipPlanes(near / 1.5, far * 1.5);
+            (xr as unknown as { _setClipPlanes: (near: number, far: number) => void })._setClipPlanes(
+                near / 1.5,
+                far * 1.5
+            );
 
             this.events.fire('xr:update');
         });


### PR DESCRIPTION
Part of playcanvas/eslint-config#48.

## Scope

- Migrates from ESLint config v2 to 3.0.0-beta.8 with the TypeScript and React presets, shared Prettier formatting, and CI type checking.
- Replaces explicit any annotations and legacy suppressions with sound DOM, loader, asset-module, and property-value types without weakening no-explicit-any.
- Preserves application behavior: formatting and type-only edits erase at runtime; the remaining ownership checks and import ordering retain existing semantics.

## Manual smoke test

1. Serve this branch locally and open https://playcanvas.com/viewer/?use_local_frontend through the local-frontend override. The Model Viewer shell and canvas should initialize.
2. Load a GLB URL. The model should render and the scene statistics and hierarchy should populate.
3. Pause and resume animation, orbit the camera, switch between orbit and fly modes, and select a hierarchy node. Each control should update the viewport.
4. Change FOV and select ACES tone mapping. The observer and camera should apply both settings without Model Viewer console errors.