### PR TITLE
feat: refresh model viewer UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,11 +46,12 @@
     "scripts": {
         "build": "vite build",
         "develop": "cross-env BUILD_TYPE=debug concurrently --kill-others \"npm run watch\" \"npm run serve\"",
-        "fmt": "prettier --check src vite.config.mjs eslint.config.mjs prettier.config.mjs",
-        "fmt:fix": "prettier --write src vite.config.mjs eslint.config.mjs prettier.config.mjs",
-        "lint": "eslint src vite.config.mjs eslint.config.mjs prettier.config.mjs",
-        "lint:fix": "eslint src vite.config.mjs eslint.config.mjs prettier.config.mjs --fix",
+        "fmt": "prettier --check src test vite.config.mjs eslint.config.mjs prettier.config.mjs",
+        "fmt:fix": "prettier --write src test vite.config.mjs eslint.config.mjs prettier.config.mjs",
+        "lint": "eslint src test vite.config.mjs eslint.config.mjs prettier.config.mjs",
+        "lint:fix": "eslint src test vite.config.mjs eslint.config.mjs prettier.config.mjs --fix",
         "serve": "serve --cors dist",
+        "test": "node --test",
         "typecheck": "tsc",
         "watch": "vite build --watch"
     },

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,5 +1,16 @@
 @use '../node_modules/@playcanvas/pcui/dist/pcui-theme-grey.scss' as *;
 
+:root {
+    --ui-accent: #f60;
+    --ui-panel: rgba(51, 51, 51, 0.88);
+    --ui-panel-solid: #282828;
+    --ui-border: rgba(255, 255, 255, 0.08);
+    --ui-text: #e0dcdd;
+    --ui-muted: #aaa;
+    --ui-radius: 8px;
+    --ui-panel-radius: 16px;
+}
+
 html {
     height: 100%;
 }
@@ -8,6 +19,16 @@ body {
     margin: 0px;
     height: 100%;
     max-height: 100%;
+    color: var(--ui-text);
+    background: #141414;
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        'Segoe UI',
+        sans-serif;
 }
 
 #app {
@@ -758,6 +779,328 @@ input {
     display: none;
 }
 
+#panel-left {
+    background: #202020;
+    border-right: 1px solid var(--ui-border);
+    box-shadow: 8px 0 24px rgba(0, 0, 0, 0.18);
+}
+
+#panel-toggle::before,
+.pcui-panel.pcui-collapsible > .pcui-panel-header::before {
+    color: var(--ui-accent) !important;
+}
+
+.pcui-panel > .pcui-panel-header {
+    min-height: 34px;
+    color: var(--ui-text);
+    background: rgba(0, 0, 0, 0.18);
+    border-bottom: 1px solid var(--ui-border);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+
+#scene-scrolly-bits {
+    scrollbar-color: rgba(255, 255, 255, 0.16) transparent;
+    scrollbar-width: thin;
+}
+
+#scene-scrolly-bits::-webkit-scrollbar {
+    width: 6px;
+}
+
+#scene-scrolly-bits::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.16);
+    border-radius: 3px;
+}
+
+.panel-option {
+    width: calc(100% - 16px);
+    min-height: 32px;
+    padding: 0 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.035);
+}
+
+#scene-panel > .pcui-panel-content > .panel-option:nth-child(even),
+#device-panel > .pcui-panel-content > .panel-option:nth-child(even) {
+    background: transparent;
+}
+
+.panel-label,
+.morph-label {
+    color: var(--ui-muted);
+    font-size: 13px;
+}
+
+.panel-value,
+.pcui-select-input-value {
+    color: var(--ui-text);
+    font-size: 13px;
+}
+
+.panel-label.pcui-disabled,
+.pcui-disabled {
+    color: #777 !important;
+}
+
+.pcui-text-input,
+.pcui-select-input,
+.pcui-numeric-input {
+    border-color: var(--ui-border) !important;
+    border-radius: 6px !important;
+    background: rgba(0, 0, 0, 0.2) !important;
+}
+
+#popup-buttons-parent {
+    bottom: max(16px, env(safe-area-inset-bottom));
+    gap: 4px;
+    padding: 4px;
+    border: 1px solid var(--ui-border);
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.32);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+}
+
+.popup-button {
+    margin: 0 !important;
+    color: var(--ui-text);
+    border: 0 !important;
+    border-radius: var(--ui-radius) !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    transition:
+        color 150ms ease,
+        background-color 150ms ease,
+        transform 150ms ease;
+}
+
+.popup-button:hover {
+    color: white;
+    background: rgba(255, 255, 255, 0.1) !important;
+}
+
+.popup-button:active {
+    transform: scale(0.96);
+}
+
+.popup-button.selected {
+    color: white;
+    background: var(--ui-accent) !important;
+}
+
+.popup-panel,
+.animation-panel,
+.selected-node-panel,
+.load-button-panel,
+.pcui-error-container,
+.pcui-warning-container {
+    color: var(--ui-text);
+    background: var(--ui-panel);
+    border: 1px solid var(--ui-border) !important;
+    border-radius: var(--ui-panel-radius);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+}
+
+.popup-panel,
+.animation-panel {
+    bottom: 84px;
+}
+
+.popup-panel-heading {
+    color: white;
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.selected-node-panel {
+    top: max(24px, env(safe-area-inset-top));
+    right: max(24px, env(safe-area-inset-right));
+}
+
+.animation-controls-panel-parent {
+    height: 40px;
+    margin: 0 4px 0 0;
+    border-right: 1px solid var(--ui-border);
+    background: transparent;
+}
+
+.anim-control-button {
+    color: var(--ui-text) !important;
+    border-radius: 6px !important;
+}
+
+#floating-top-parent {
+    top: max(16px, env(safe-area-inset-top));
+    right: max(16px, env(safe-area-inset-right));
+}
+
+#floating-bottom-parent {
+    right: max(16px, env(safe-area-inset-right));
+    bottom: max(16px, env(safe-area-inset-bottom));
+}
+
+#launch-ar-button {
+    left: max(16px, env(safe-area-inset-left));
+    bottom: max(16px, env(safe-area-inset-bottom));
+    background: rgba(0, 0, 0, 0.32) !important;
+}
+
+#fullscreen-button,
+#camera-mode-button {
+    background: rgba(0, 0, 0, 0.32) !important;
+    border: 1px solid var(--ui-border) !important;
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+}
+
+#fullscreen-button:hover,
+#camera-mode-button:hover,
+#launch-ar-button:hover {
+    background: rgba(255, 255, 255, 0.1) !important;
+}
+
+.load-button-panel {
+    overflow: hidden;
+    padding: 0 20px 20px;
+}
+
+#load-controls > .load-button-panel > .header {
+    height: 48px;
+    margin: 0 -20px 20px;
+    padding-right: 8px;
+    background: rgba(0, 0, 0, 0.16);
+    border-bottom: 1px solid var(--ui-border);
+}
+
+#drag-drop {
+    height: 152px;
+    color: var(--ui-muted);
+    background: rgba(0, 0, 0, 0.14);
+    border: 1px dashed rgba(255, 255, 255, 0.3);
+    border-radius: 10px;
+    cursor: pointer;
+    transition:
+        color 150ms ease,
+        border-color 150ms ease,
+        background-color 150ms ease;
+}
+
+#drag-drop:hover,
+#drag-drop:focus-visible {
+    color: white;
+    border-color: var(--ui-accent);
+    background: rgba(255, 102, 0, 0.08);
+}
+
+#drag-drop-search-icon {
+    width: 32px;
+    height: 32px;
+    color: var(--ui-accent);
+    font-family: 'pc-icon';
+    font-size: 24px;
+    text-align: center;
+}
+
+#drag-drop-search-icon::before {
+    content: '\E129';
+}
+
+#glb-url-button {
+    height: 36px;
+    color: white;
+    border: 0;
+    border-radius: 8px;
+    background: var(--ui-accent);
+    text-align: center;
+}
+
+.pcui-error-container,
+.pcui-warning-container {
+    width: min(500px, calc(100% - 64px));
+}
+
+.pcui-infobox.pcui-error .pcui-infobox-title,
+.pcui-infobox.pcui-error::before {
+    color: #ff6565;
+}
+
+.pcui-infobox.pcui-warning .pcui-infobox-title,
+.pcui-infobox.pcui-warning::before {
+    color: #ffb44d;
+}
+
+.pcui-button:focus-visible,
+#drag-drop:focus-visible {
+    outline: 2px solid white;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px rgba(255, 102, 0, 0.55) !important;
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+    #popup-buttons-parent,
+    .popup-panel,
+    .animation-panel,
+    .selected-node-panel,
+    .load-button-panel,
+    .pcui-error-container,
+    .pcui-warning-container {
+        background: var(--ui-panel-solid);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+    }
+}
+
+@media only screen and (max-width: 950px) {
+    #popup > #popup-buttons-parent {
+        bottom: max(12px, env(safe-area-inset-bottom));
+        margin: 0 !important;
+    }
+
+    #popup > #popup-buttons-parent > .pcui-button,
+    #floating-bottom-parent > .pcui-button,
+    #launch-ar-button {
+        width: 44px !important;
+        height: 44px !important;
+    }
+
+    #fullscreen-button {
+        display: none;
+    }
+
+    #popup > .popup-panel-parent > .popup-panel {
+        width: calc(100% - 64px);
+        max-height: calc(100% - 160px);
+        bottom: calc(max(12px, env(safe-area-inset-bottom)) + 64px);
+        overflow-y: auto;
+    }
+
+    .selected-node-panel {
+        top: max(12px, env(safe-area-inset-top));
+        right: 12px;
+        left: 12px;
+        width: auto;
+        margin: 0;
+    }
+
+    .load-button-panel {
+        width: calc(100% - 72px);
+        max-height: calc(100% - 48px);
+    }
+}
+
 #panel-toggle > img {
     z-index: 9999;
     width: 42px;
@@ -850,49 +1193,51 @@ input {
 }
 
 .font-thin {
-    font-family: 'Proxima Nova Thin', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    font-family: inherit;
     font-weight: 100;
     font-style: normal;
 }
 
 .font-light {
-    font-family: 'Proxima Nova Light', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    font-family: inherit;
     font-weight: 200;
     font-style: normal;
 }
 
 .font-regular {
-    font-family: 'Proxima Nova Regular', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    font-family: inherit;
     font-weight: normal;
     font-style: normal;
 }
 
 .font-bold {
-    font-family: 'Proxima Nova Bold', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    font-family: inherit;
     font-weight: bold;
     font-style: normal;
 }
 
 .pcui-button {
-    border-radius: 0px !important;
+    border-radius: 6px !important;
 }
 
 .pcui-button.secondary {
     min-height: 38px;
-    background-color: white;
-    color: black !important;
-    border-radius: 0px;
-    border: none;
+    color: var(--ui-text) !important;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--ui-border);
+    border-radius: var(--ui-radius) !important;
 }
 
 .pcui-button.secondary:not(.pcui-disabled):hover {
     color: white !important;
+    background: rgba(255, 255, 255, 0.14);
 }
 
 .pcui-text-input.secondary {
-    min-height: 48px;
-    border-radius: 0;
-    border: none;
+    min-height: 40px;
+    border: 1px solid var(--ui-border);
+    border-radius: var(--ui-radius) !important;
+    background: rgba(0, 0, 0, 0.2) !important;
     color: white !important;
 }
 
@@ -946,4 +1291,35 @@ input {
     .pcui-select-input-list
     > .pcui-select-input-label-highlighted {
     background-color: $bcg-primary;
+}
+
+.panel-label.pcui-label,
+.morph-label.pcui-label {
+    color: var(--ui-muted) !important;
+    font-size: 13px !important;
+}
+
+.panel-label.pcui-label.pcui-disabled {
+    color: #777 !important;
+}
+
+.pcui-boolean-input-toggle.pcui-boolean-input-ticked {
+    border-color: rgba(255, 102, 0, 0.5);
+    background: rgba(255, 102, 0, 0.3);
+}
+
+.pcui-boolean-input-toggle.pcui-boolean-input-ticked::after,
+.pcui-boolean-input-toggle.pcui-boolean-input-ticked:hover::after,
+.pcui-boolean-input-toggle.pcui-boolean-input-ticked:focus::after {
+    background: var(--ui-accent);
+}
+
+.pcui-slider-handle {
+    background: var(--ui-accent) !important;
+}
+
+#glb-url-button {
+    color: white !important;
+    background: var(--ui-accent);
+    border-radius: var(--ui-radius) !important;
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -110,6 +110,7 @@ body {
 
 #canvas-wrapper {
     position: relative;
+    container-type: inline-size;
     width: 0 !important;
     flex-grow: 1;
     display: flex;
@@ -736,16 +737,6 @@ input {
         display: none;
     }
 
-    #popup > #popup-buttons-parent > .animation-controls-panel-parent {
-        flex-wrap: wrap;
-        height: fit-content !important;
-        width: 220px;
-        position: absolute;
-        bottom: 50px;
-        left: -8px;
-        padding: 6px !important;
-    }
-
     .selected-node-panel {
         position: fixed !important;
         width: inherit;
@@ -868,7 +859,7 @@ input {
     color: var(--ui-text);
     border: 0 !important;
     border-radius: var(--ui-radius) !important;
-    background: transparent !important;
+    background-color: transparent !important;
     box-shadow: none !important;
     transition:
         color 150ms ease,
@@ -878,7 +869,7 @@ input {
 
 .popup-button:hover {
     color: white;
-    background: rgba(255, 255, 255, 0.1) !important;
+    background-color: rgba(255, 255, 255, 0.1) !important;
 }
 
 .popup-button:active {
@@ -887,7 +878,7 @@ input {
 
 .popup-button.selected {
     color: white;
-    background: var(--ui-accent) !important;
+    background-color: var(--ui-accent) !important;
 }
 
 .popup-panel,
@@ -946,12 +937,12 @@ input {
 #launch-ar-button {
     left: max(16px, env(safe-area-inset-left));
     bottom: max(16px, env(safe-area-inset-bottom));
-    background: rgba(0, 0, 0, 0.32) !important;
+    background-color: rgba(0, 0, 0, 0.32) !important;
 }
 
 #fullscreen-button,
 #camera-mode-button {
-    background: rgba(0, 0, 0, 0.32) !important;
+    background-color: rgba(0, 0, 0, 0.32) !important;
     border: 1px solid var(--ui-border) !important;
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
@@ -960,7 +951,7 @@ input {
 #fullscreen-button:hover,
 #camera-mode-button:hover,
 #launch-ar-button:hover {
-    background: rgba(255, 255, 255, 0.1) !important;
+    background-color: rgba(255, 255, 255, 0.1) !important;
 }
 
 .load-button-panel {
@@ -1076,6 +1067,10 @@ input {
         height: 44px !important;
     }
 
+    #popup > #popup-buttons-parent > .pcui-button {
+        margin: 0 !important;
+    }
+
     #fullscreen-button {
         display: none;
     }
@@ -1088,7 +1083,7 @@ input {
     }
 
     .selected-node-panel {
-        top: max(12px, env(safe-area-inset-top));
+        top: max(54px, calc(env(safe-area-inset-top) + 12px));
         right: 12px;
         left: 12px;
         width: auto;
@@ -1098,6 +1093,48 @@ input {
     .load-button-panel {
         width: calc(100% - 72px);
         max-height: calc(100% - 48px);
+    }
+}
+
+@container (max-width: 920px) {
+    #popup > #popup-buttons-parent > .animation-controls-panel-parent {
+        position: absolute;
+        left: 50%;
+        bottom: 62px;
+        box-sizing: border-box;
+        width: min(360px, calc(100cqw - 32px));
+        height: 48px !important;
+        padding: 4px !important;
+        gap: 4px;
+        border-right: 0;
+        transform: translateX(-50%);
+    }
+
+    #anim-track-select {
+        width: 100px !important;
+        min-width: 0;
+    }
+
+    #anim-scrub-slider {
+        width: auto !important;
+        min-width: 80px;
+        flex: 1;
+    }
+
+    #anim-speed-select {
+        width: 52px !important;
+        min-width: 52px;
+    }
+
+    #popup:has(.animation-controls-panel-parent) > .popup-panel-parent > .popup-panel {
+        bottom: calc(max(12px, env(safe-area-inset-bottom)) + 136px);
+        max-height: calc(100% - 220px);
+    }
+}
+
+@media only screen and (max-width: 950px) and (max-height: 430px) {
+    .load-button-panel {
+        width: min(500px, calc(100% - 142px));
     }
 }
 

--- a/src/ui/components/index.tsx
+++ b/src/ui/components/index.tsx
@@ -1,5 +1,6 @@
 import {
     BooleanInput,
+    Button,
     ColorPicker,
     Container,
     Label,
@@ -11,6 +12,19 @@ import {
 import React from 'react';
 
 import type { Option } from '../../types';
+
+export const IconButton = ({ label, ...props }: React.ComponentProps<typeof Button> & { label: string }) => {
+    const ref = React.useRef<React.ElementRef<typeof Button>>(null);
+
+    React.useEffect(() => {
+        const dom = ref.current?.element.dom;
+        if (!dom) return;
+        dom.setAttribute('aria-label', label);
+        dom.title = label;
+    }, [label]);
+
+    return <Button ref={ref} {...props} />;
+};
 
 export const Detail = (props: { label: string; value: string | number }) => {
     return (

--- a/src/ui/load-controls.tsx
+++ b/src/ui/load-controls.tsx
@@ -4,6 +4,8 @@ import React, { useRef, useState } from 'react';
 import { version as appVersion } from '../../package.json';
 import type { File, SetProperty } from '../types';
 
+import { IconButton } from './components';
+
 const validUrl = (url: string) => {
     try {
         new URL(url);
@@ -57,12 +59,12 @@ const LoadControls = (props: { setProperty: SetProperty }) => {
         <div id="load-controls">
             <Container class="load-button-panel" enabled flex>
                 <div className="header">
-                    {/* eslint-disable-next-line jsx-a11y/alt-text -- preserve markup */}
-                    <img src={'static/playcanvas-logo.png'} />
+                    <img src={'static/playcanvas-logo.png'} alt="" />
                     <div>
                         <Label text={`MODEL VIEWER v${appVersion}`} />
                     </div>
-                    <Button
+                    <IconButton
+                        label="Open Model Viewer on GitHub"
                         onClick={() => {
                             window.open('https://github.com/playcanvas/model-viewer', '_blank').focus();
                         }}
@@ -78,9 +80,18 @@ const LoadControls = (props: { setProperty: SetProperty }) => {
                     ref={inputFile}
                     style={{ display: 'none' }}
                 />
-                {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- preserve drag-drop behavior */}
-                <div id="drag-drop" onClick={onLoadButtonClick}>
-                    <Button id="drag-drop-search-icon" icon="E129" />
+                <div
+                    id="drag-drop"
+                    role="button"
+                    tabIndex={0}
+                    onClick={onLoadButtonClick}
+                    onKeyDown={(event) => {
+                        if (event.key !== 'Enter' && event.key !== ' ') return;
+                        event.preventDefault();
+                        onLoadButtonClick();
+                    }}
+                >
+                    <span id="drag-drop-search-icon" aria-hidden="true" />
                     <Label class="desktop" text="Drag & drop .glb, .gltf, or .ply files, or click to open files" />
                     <Label class="mobile" text="Click to open files" />
                 </div>

--- a/src/ui/popup-panel/animation-controls.tsx
+++ b/src/ui/popup-panel/animation-controls.tsx
@@ -1,8 +1,7 @@
-import { Button } from '@playcanvas/pcui/react';
 import React from 'react';
 
 import type { SetProperty, ObserverData } from '../../types';
-import { NakedSelect, NakedSlider } from '../components';
+import { IconButton, NakedSelect, NakedSlider } from '../components';
 
 class AnimationTrackSelect extends React.Component<{
     animationData: ObserverData['animation'];
@@ -98,7 +97,8 @@ class AnimationControls extends React.Component<{
 
         return enabled ? (
             <div className="animation-controls-panel-parent">
-                <Button
+                <IconButton
+                    label={props.animationData.playing ? 'Pause animation' : 'Play animation'}
                     class="anim-control-button"
                     width={30}
                     height={30}

--- a/src/ui/popup-panel/index.tsx
+++ b/src/ui/popup-panel/index.tsx
@@ -1,10 +1,10 @@
-import { Button } from '@playcanvas/pcui/react';
 import { UsdzExporter } from 'playcanvas';
 import type { Entity } from 'playcanvas';
 import React from 'react';
 
 import { addEventListenerOnClickOnly } from '../../helpers';
 import type { SetProperty, ObserverData } from '../../types';
+import { IconButton } from '../components';
 
 import AnimationControls from './animation-controls';
 import { CameraPanel, SkyboxPanel, LightPanel, SettingsPanel, ViewPanel } from './panels';
@@ -70,35 +70,40 @@ class PopupButtonControls extends React.Component<{ observerData: ObserverData; 
                     animationData={this.props.observerData.animation}
                     setProperty={this.props.setProperty}
                 />
-                <Button
+                <IconButton
+                    label="Camera"
                     class={buildClass('camera')}
                     icon="E212"
                     width={40}
                     height={40}
                     onClick={() => handleClick('camera')}
                 />
-                <Button
+                <IconButton
+                    label="Environment"
                     class={buildClass('skybox')}
                     icon="E200"
                     width={40}
                     height={40}
                     onClick={() => handleClick('skybox')}
                 />
-                <Button
+                <IconButton
+                    label="Light"
                     class={buildClass('light')}
                     icon="E194"
                     width={40}
                     height={40}
                     onClick={() => handleClick('light')}
                 />
-                <Button
+                <IconButton
+                    label="Settings"
                     class={buildClass('settings')}
                     icon="E134"
                     width={40}
                     height={40}
                     onClick={() => handleClick('settings')}
                 />
-                <Button
+                <IconButton
+                    label="View and share"
                     class={buildClass('view')}
                     icon="E301"
                     width={40}
@@ -143,7 +148,8 @@ class PopupPanel extends React.Component<{ observerData: ObserverData; setProper
             <div id="popup" className={this.props.observerData.scene.nodes === '[]' ? 'empty' : null}>
                 <PopupPanelControls observerData={this.props.observerData} setProperty={this.props.setProperty} />
                 <PopupButtonControls observerData={this.props.observerData} setProperty={this.props.setProperty} />
-                <Button
+                <IconButton
+                    label="Launch AR"
                     class="popup-button"
                     id="launch-ar-button"
                     icon="E189"
@@ -168,7 +174,8 @@ class PopupPanel extends React.Component<{ observerData: ObserverData; setProper
                     }}
                 />
                 <div id="floating-top-parent">
-                    <Button
+                    <IconButton
+                        label="Toggle inspector"
                         class="popup-button"
                         id="fullscreen-button"
                         icon="E127"
@@ -180,7 +187,8 @@ class PopupPanel extends React.Component<{ observerData: ObserverData; setProper
                     />
                 </div>
                 <div id="floating-bottom-parent">
-                    <Button
+                    <IconButton
+                        label={`Switch to ${this.props.observerData.camera.mode === 'orbit' ? 'fly' : 'orbit'} mode`}
                         class={['popup-button', 'camera-mode-button', this.props.observerData.camera.mode]}
                         id="camera-mode-button"
                         width={40}

--- a/src/ui/popup-panel/panels.tsx
+++ b/src/ui/popup-panel/panels.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { extract } from '../../helpers';
 import type { SetProperty, ObserverData } from '../../types';
-import { Detail, Slider, Toggle, Select, ColorPickerControl, ToggleColor, Numeric } from '../components';
+import { Detail, Slider, Toggle, Select, ColorPickerControl, ToggleColor, Numeric, IconButton } from '../components';
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- declaration merging
@@ -422,7 +422,8 @@ const ShareControls = (props: { url: string }) => (
         <Label text="View and share on mobile with URL" />
         <div id="share-url-wrapper">
             <TextInput class="secondary" value={props.url} enabled={false} />
-            <Button
+            <IconButton
+                label="Copy share URL"
                 id="copy-button"
                 icon="E126"
                 onClick={() => {

--- a/test/ui-refresh.test.mjs
+++ b/test/ui-refresh.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const style = await readFile(new URL('../src/style.scss', import.meta.url), 'utf8');
+const components = await readFile(new URL('../src/ui/components/index.tsx', import.meta.url), 'utf8');
+const load = await readFile(new URL('../src/ui/load-controls.tsx', import.meta.url), 'utf8');
+
+test('defines the shared viewer theme tokens', () => {
+    for (const token of ['--ui-accent: #f60', '--ui-panel:', '--ui-border:', '--ui-text:', '--ui-radius:']) {
+        assert.match(style, new RegExp(token));
+    }
+});
+
+test('supports reduced motion, safe areas and opaque panel fallbacks', () => {
+    assert.match(style, /prefers-reduced-motion/);
+    assert.match(style, /safe-area-inset-bottom/);
+    assert.match(style, /@supports not \(backdrop-filter/);
+});
+
+test('gives icon-only controls accessible names and tooltips', () => {
+    assert.match(components, /export const IconButton/);
+    assert.match(components, /setAttribute\('aria-label', label\)/);
+    assert.match(components, /\.title = label/);
+});
+
+test('makes the file drop zone keyboard accessible', () => {
+    assert.match(load, /role="button"/);
+    assert.match(load, /tabIndex=\{0\}/);
+    assert.match(load, /onKeyDown=/);
+});


### PR DESCRIPTION
Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

## Summary

- refresh the viewer with SuperSplat-inspired dark surfaces and orange active states
- unify floating controls, inspector styling, dialogs, loading UI, and responsive touch targets
- add accessible labels, keyboard file loading, reduced-motion support, and UI contract tests

## Verification

- `npm test`
- `npm run fmt`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

## Manual smoke tests

1. Open the viewer without a model; expect the refreshed loading card, responsive drop zone, and URL controls to be visible and usable.
2. Load a GLB, glTF, or PLY file; expect the model to render and the inspector, hierarchy, and bottom toolbar to retain their existing behavior.
3. Open each camera, environment, light, settings, and sharing panel; expect one styled panel at a time and outside-click dismissal to continue working.
4. Use keyboard navigation through icon controls and the drop zone; expect descriptive tooltips, visible focus rings, and Enter/Space to open the file picker.
5. Resize below 950px and test portrait and landscape layouts; expect 44px controls, safe-area spacing, and panels contained within the viewport.
